### PR TITLE
(fix) improves clarity

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -166,7 +166,7 @@ If starting a new story on a sprint, remember to hit “start” on the story in
 
 #### Committing
 
-Messages should convey in the present tense what the __new state__ of the system will be. There is no strict character limit for this but you should expect them to usually be below 50.
+Messages should convey in the present tense what the __new state__ of the system will be. There is no strict character limit for this but you should try to stay under 50 characters.
 
 To help focus our commits into smaller well-bounded chunks we prepend the following for each type of commit.
 


### PR DESCRIPTION
"you should expect them to usually be below" doesn't quite parse right. Should I expect them to usually be below that number when other people write them? Instead of phrasing it as an expectation, phrase it as an aim or goal.