### PR TITLE
Add note about using "Resolves:" in commit messages

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -201,10 +201,16 @@ Every project will grow and with it the number of decision making processes we g
 
 Recording what these are is extremely helpful to enable anybody working on the project now and in the future to make informed decisions by reading the commit history.
 
+After the description there should be a line that starts with `Fixes:` followed by a link to the Zendesk ticket, Pivotal story, or GitHub issue (do not use `#123` instead of providing the full URL - who knows if that's a GitHub issue or a Zendesk ticket). This should not be used as a substitute for a description - the description will last as long as the repository, the link to Zendesk will last as long as Zendesk is profitable. Naming the branch `hotfix/123` is not a substitute for including this line as branch names are ephemeral and only recorded on the merge commit (and there's no easy way to find a merge commit from a commit).
+
+If a single ticket/story is being completed, a squashed commit is preferred over multiple commits.
+
 
 ```
 # Poor
 Fixed the form
+
+Fixes: #123
 
 # Great
 (fix): Food order form works with special characters
@@ -212,6 +218,8 @@ Fixed the form
 * Previously the form failed to send if the starter value included any of the following characters: !@£$%^&*().:;'
 * Users should be able to use these characters and after a short investigation I found this new bug in PHP: <link>
 * As a short term workaround until the bug is fixed I am stripping out any of these characters if they are present.
+
+Fixes: https://dxw.zendesk.com/agent/tickets/0000
 ```
 
 #### Code style

--- a/playbook.md
+++ b/playbook.md
@@ -201,16 +201,18 @@ Every project will grow and with it the number of decision making processes we g
 
 Recording what these are is extremely helpful to enable anybody working on the project now and in the future to make informed decisions by reading the commit history.
 
-After the description there should be a line that starts with `Fixes:` followed by a link to the Zendesk ticket, Pivotal story, or GitHub issue (do not use `#123` instead of providing the full URL - who knows if that's a GitHub issue or a Zendesk ticket). This should not be used as a substitute for a description - the description will last as long as the repository, the link to Zendesk will last as long as Zendesk is profitable. Naming the branch `hotfix/123` is not a substitute for including this line as branch names are ephemeral and only recorded on the merge commit (and there's no easy way to find a merge commit from a commit).
+After the description there should be a line that starts with `Resolves:` followed by a link to the Zendesk ticket, Pivotal story, or GitHub issue (do not use `#123` instead of providing the full URL - who knows if that's a GitHub issue or a Zendesk ticket). This should not be used as a substitute for a description - the description will last as long as the repository, the link to Zendesk will last as long as Zendesk is profitable. Naming the branch `hotfix/123` is not a substitute for including this line as branch names are ephemeral and only recorded on the merge commit (and there's no easy way to find a merge commit from a commit).
 
-If a single ticket/story is being completed, a squashed commit is preferred over multiple commits.
+Other links relevant to the commit should be added as lines beginning with `Link:`.
+
+If a single ticket/story is being completed, a [squashed commit](https://robots.thoughtbot.com/git-interactive-rebase-squash-amend-rewriting-history#squash-commits-together) is preferred over multiple commits.
 
 
 ```
 # Poor
 Fixed the form
 
-Fixes: #123
+Resolves: #123
 
 # Great
 (fix): Food order form works with special characters
@@ -219,7 +221,8 @@ Fixes: #123
 * Users should be able to use these characters and after a short investigation I found this new bug in PHP: <link>
 * As a short term workaround until the bug is fixed I am stripping out any of these characters if they are present.
 
-Fixes: https://dxw.zendesk.com/agent/tickets/0000
+Resolves: https://dxw.zendesk.com/agent/tickets/0000
+Link: http://grimm.blog/solution-to-ie7-render-bug
 ```
 
 #### Code style


### PR DESCRIPTION
I've been using a mixture of `Ticket: https://dxw.zendesk.com/...`, `Story: https://www.pivotaltracker.com/...` and `Fixes: #123` (for GitHub issues) for a while now, but I'd like to standardise, and it would be good to get some consistency on this.

On the subject of commit squashing - I used to make very small commits, but as I've started to use TDD more I've gravitated to larger commits, and it seems like it's easier to write a detailed description for a monolithic commit than it is for microcommits. It also has a side-effect of making rebasing easier which makes my life easier, and will probably be much much easier for the less experienced git users.
