### PR TITLE
Remove the lateness link as that section no longer exists

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -76,7 +76,7 @@ However, there are some things that we must keep private.
 ### Time
 Our working hours are 10:00-18:00, Monday to Friday. Some people work different hours by arrangement. Anyone is free to do that as long as their hours of work don't make it hard for other people to get things done. For example, many people arrive earlier than 10:00 and leave earlier, which is generally fine.
 
-We have a short stand-up every morning, where we each tell the whole team about a single thing we will get done that day. The stand-up is at 10:00. If you miss the stand-up, then you are [late](#lateness).
+We have a short stand-up every morning, where we each tell the whole team about a single thing we will get done that day. The stand-up is at 10:00. If you miss the stand-up, then you are late.
 
 Most developers have maintenance responsibilities, which they do during [ticket time](#ticket-time).
 


### PR DESCRIPTION
Not sure where the section went so the link should be removed.