### PR TITLE
When deploying, pull before merging into master

### DIFF
--- a/guides/development-workflow.md
+++ b/guides/development-workflow.md
@@ -190,6 +190,7 @@ To deploy:
   ```
   git fetch
   git checkout master
+  git pull
   git merge origin/develop
   git push
   ```


### PR DESCRIPTION
The current instructions say to fetch master but not to pull it before merging.

Fetching updates the dev's view of which commit the remote master is pointing at, but doesn't update their local master branch, so that may be behind.

If the dev's local master branch is behind origin/master then following these instructions to the letter will result in the incorrect merge happening. I _think_ this should lead to a failure when pushing (remote and local master will now both have commits which the other doesn't have), and it is recoverable, but will probably lead to a messy and confusing commit history.