### PR TITLE
Theme navigation tweaks

### DIFF
--- a/build/assets/css/styles.css
+++ b/build/assets/css/styles.css
@@ -144,3 +144,11 @@ a.skip:hover {
   padding: 5px;
   display: inline-block;
 }
+
+[data-page="playbook.md"] .sidebar-nav > ul > li {
+  display: none;
+}
+
+[data-page="playbook.md"] .sidebar-nav > ul > ul {
+  margin-left: 0;
+}

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       repo: '',
       loadNavbar: 'build/partials/_navbar.md',
       homepage: 'playbook.md',
-      maxLevel: 4,
+      maxLevel: 3,
       themeColor: '#006998',
       ga: 'UA-29555961-6',
       formatUpdated: '{DD}/{MM}/{YY}',


### PR DESCRIPTION
Some users were finding it difficult to find the section they wanted to because of the amount of items in the navigation.

This PR aims to improve the playbook theme's navigation by:

- Reducing the level of the navigation to 3 heading levels, it was 4 previously
- Hiding the repeated top level navigation item on the main playbook page

## Before 
<img width="299" alt="screenshot 2018-11-02 at 16 07 12" src="https://user-images.githubusercontent.com/2804149/47926803-68996700-deb9-11e8-88f1-b0a9475610bd.png">

## After 
<img width="300" alt="screenshot 2018-11-02 at 16 05 29" src="https://user-images.githubusercontent.com/2804149/47926751-49023e80-deb9-11e8-8420-2f7044fd51c4.png">




