### PR TITLE
Remove Research activities from the navigation

### DIFF
--- a/build/partials/_navbar.md
+++ b/build/partials/_navbar.md
@@ -8,8 +8,6 @@
   - [Plugin advisories](guides/plugin-advisories.md)
   - [Style guide](guides/style-guide.md)
   - [Contributing to the Playbook](contributing.md)
-- Research activities
-  - [Card sort](research-activities/card-sort.md)
 
 <div class="logo"> 
   <img src="build/assets/img/dxw-marker.svg" height="32px">


### PR DESCRIPTION
It has been requested that we remove the link to the research activities for now, while the UR team has time to generate some more content.

https://trello.com/c/bPpddj3S/328-remove-research-activities-tab-on-playbook