### PR TITLE
(feature) Add automated markdown linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+cache: bundler
+script: ./test.sh
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem "mdl"
+gem "travis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,61 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.4.0)
+    backports (3.11.3)
+    ethon (0.11.0)
+      ffi (>= 1.3.0)
+    faraday (0.15.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
+    ffi (1.9.25)
+    gh (0.15.1)
+      addressable (~> 2.4.0)
+      backports
+      faraday (~> 0.8)
+      multi_json (~> 1.0)
+      net-http-persistent (~> 2.9)
+      net-http-pipeline
+    highline (1.7.10)
+    json (2.1.0)
+    kramdown (1.17.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    mdl (0.4.0)
+      kramdown (~> 1.12, >= 1.12.0)
+      mixlib-cli (~> 1.7, >= 1.7.0)
+      mixlib-config (~> 2.2, >= 2.2.1)
+    mixlib-cli (1.7.0)
+    mixlib-config (2.2.8)
+      tomlrb
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    net-http-persistent (2.9.4)
+    net-http-pipeline (1.0.1)
+    pusher-client (0.6.2)
+      json
+      websocket (~> 1.0)
+    tomlrb (1.2.7)
+    travis (1.8.8)
+      backports
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9, >= 0.9.1)
+      gh (~> 0.13)
+      highline (~> 1.6)
+      launchy (~> 2.1)
+      pusher-client (~> 0.4)
+      typhoeus (~> 0.6, >= 0.6.8)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    websocket (1.2.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mdl
+  travis
+
+BUNDLED WITH
+   1.16.1

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# script to test the playbook
+echo "=> linting .travis.yml..."
+bundle exec travis lint --no-interactive
+echo "=> linting markdown..."
+bundle exec mdl -g .


### PR DESCRIPTION
Add markdown linting to our playbook so that we are consistent in our
markdown usage.

This commit adds the following to do that:

- a `Gemfile` and `Gemfile.lock` to install `mdl` a markdown linter and the
  `travis` gem to lint our `.travis.yml`
- a `.travis.yml` to enable the linting of markdown
- a script to run the linting.