### PR TITLE
Add redirect for deep links

### DIFF
--- a/build/assets/js/redirect-deeplinks.js
+++ b/build/assets/js/redirect-deeplinks.js
@@ -1,0 +1,18 @@
+(function () {
+    'use strict';
+    var redirectDeeplinks = function (hook, vm) {
+      hook.mounted(function () {
+        var route = vm.route;
+        window.Docsify.get(
+          route.file,
+          false,
+          {}
+        ).then(function (){}, function (e) {
+          if (e.status === 404) {
+            window.location = '/#/?id=' + route.path.replace('/', '');
+          }
+        });
+      });
+    };
+    $docsify.plugins = [].concat(redirectDeeplinks, $docsify.plugins);
+}());

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
   <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
   <script src="//unpkg.com/docsify/lib/plugins/ga.min.js"></script>
   <script src="build/assets/js/skip-to-content.js"></script>
+  <script src="build/assets/js/redirect-deeplinks.js"></script>
   <!--[if lte IE 8]>
   <script src="build/assets/js/ie8-github-redirect.js"></script>
   <![endif]-->


### PR DESCRIPTION
When we started using Docsify back in February any links to a specific section of the playbook that used a URL fragment (eg. http://playbook.dxw.com/#sales) would result in a 404 error message.
This is because of the internal routing method that Docsify uses.

Unfortunately there's no official hook for a 404 in Docsify so we have to do an AJAX call to see if the requested fragment is in fact not a file and probably just a section of the playbook.

With this fix, the URL `http://localhost:3000/#sales` will redirect to `http://localhost:3000/#/?id=sales`

and `http://localhost:3000/#doesnt_exist` just goes to the top of the playbook

Resolves: https://dxw.slack.com/archives/C025PM7N8/p1528286714000354