### PR TITLE
Ask people to record holiday in calendar

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -1447,6 +1447,9 @@ If you want to take time off:
   the impact it will have on the team and the project
 * **Request the holiday through BreatheHR**: we use BreatheHR to track who's
   off when so we can plan for it
+* **Add your holiday to your calendar**: if someone is trying to find out where
+  you are or when you're available the first thing they'll check is your
+  calendar
 
 We try very hard to make sure that all holiday requests are granted,
 irrespective of when they are made. But it's much easier for delivery managers

--- a/playbook.md
+++ b/playbook.md
@@ -1441,11 +1441,12 @@ For any other salary queries, please speak to your head-of or the Managing Direc
 
 ### Holiday
 
-We use BreatheHR to manage holiday requests.
+If you want to take time off:
 
-If you want to take holiday, first discuss the dates you plan to be away with
-your team so that they know when you're planning to go. Then request the holiday
-through BreatheHR.
+* **Discuss the dates with your team**: this gives them a chance to think about
+  the impact it will have on the team and the project
+* **Request the holiday through BreatheHR**: we use BreatheHR to track who's
+  off when so we can plan for it
 
 We try very hard to make sure that all holiday requests are granted,
 irrespective of when they are made. But it's much easier for delivery managers


### PR DESCRIPTION
Add clearer reasons for the different steps of the holiday process and add a step about updating your own calendar.

Understanding why the process is as it is helps people see the value in following it, and makes it easier to challenge or change parts of it.