### PR TITLE
Feature/add prose linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
-language: ruby
-cache: bundler
-script: ./test.sh
+matrix:
+  include:
+    - language: ruby
+      cache: bundler
+      script: ./test.sh
+    - language: python
+      python: 2.7.15
+      install:
+        - go get github.com/ValeLint/vale
+      script:
+        - vale playbook.md
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ matrix:
       install:
         - go get github.com/ValeLint/vale
       script:
-        - vale playbook.md
+        - vale playbook.md && vale contributing.md && vale README.md
+        - vale guides
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ matrix:
         - go get github.com/ValeLint/vale
       script:
         - vale playbook.md && vale contributing.md && vale README.md
-        - vale guides
+        - vale --glob='!*style-guide.md' guides
 

--- a/.vale.ini
+++ b/.vale.ini
@@ -6,3 +6,8 @@ MinAlertLevel = warning # suggestion, warning or error
 BasedOnStyles = dxw,govuk
 # Style.Rule = {YES, NO, suggestion, warning, error} to
 # enable/disable a rule or change its level.
+proselint.Cursing = YES
+proselint.LGBTOffensive = YES
+proselint.LGBTTerms = YES
+proselint.GenderBias = YES
+

--- a/.vale.ini
+++ b/.vale.ini
@@ -3,6 +3,6 @@ MinAlertLevel = warning # suggestion, warning or error
 # Only Markdown and .txt files; change to whatever you're using.
 [*.{md}]
 # List of styles to load.
-BasedOnStyles = dxw
+BasedOnStyles = dxw,govuk
 # Style.Rule = {YES, NO, suggestion, warning, error} to
 # enable/disable a rule or change its level.

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,8 @@
+StylesPath = styles
+MinAlertLevel = warning # suggestion, warning or error
+# Only Markdown and .txt files; change to whatever you're using.
+[*.{md}]
+# List of styles to load.
+BasedOnStyles = dxw
+# Style.Rule = {YES, NO, suggestion, warning, error} to
+# enable/disable a rule or change its level.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ dependencies:
 
 ```
 npm install
+go get github.com/errata-ai/vale
 ```
 
 Then to start a local development server run:
@@ -95,4 +96,10 @@ Check your changes for markdown errors:
 
 ```
 ./test.sh
+```
+
+To run the prose linter:
+
+```
+vale [fileYouWantToLint].md
 ```

--- a/styles/dxw/G-Cloud.yml
+++ b/styles/dxw/G-Cloud.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "G-Cloud not '%s'"
+level: error
+ignorecase: false
+raw:
+  - (?:\bG-cloud\b|\bG Cloud\b|\bG cloud\b|\bg-cloud\b|\bGCloud\b|\bGcloud\b)

--- a/styles/dxw/GovPress.yml
+++ b/styles/dxw/GovPress.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "GovPress not '%s'"
+level: error
+ignorecase: false
+raw:
+  - (?:\bGovpress\b|\bGov Press\b)

--- a/styles/dxw/WordPress.yml
+++ b/styles/dxw/WordPress.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "WordPress not '%s'"
+level: error
+ignorecase: false
+raw:
+  - (?:\bWordpress\b|\bWP\b|\bWord Press\b)

--- a/styles/dxw/WordPress.yml
+++ b/styles/dxw/WordPress.yml
@@ -3,4 +3,4 @@ message: "WordPress not '%s'"
 level: error
 ignorecase: false
 raw:
-  - (?:\bWordpress\b|\bWP\b|\bWord Press\b)
+  - (?:\bWordpress\|\bWord Press\b|\bWord press\b)

--- a/styles/dxw/digital-marketplace.yml
+++ b/styles/dxw/digital-marketplace.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "Digital Marketplace not '%s'"
+level: error
+ignorecase: false
+raw:
+  - (?:\bDigital marketplace\b|\bdigital marketplace\b)

--- a/styles/dxw/dxw.yml
+++ b/styles/dxw/dxw.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: dxw should be all lowercase
+level: error
+ignorecase: false
+raw:
+  - (?:\bDXW\b|\bDxw\b)

--- a/styles/dxw/multisite.yml
+++ b/styles/dxw/multisite.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "multisite not '%s'"
+level: error
+ignorecase: true
+raw:
+  - (?:\bmulti-site\b|\bmulti site\b)

--- a/styles/dxw/plugin.yml
+++ b/styles/dxw/plugin.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "plugin not '%s'"
+level: error
+ignorecase: true
+raw:
+  - (?:\bplug-in\b)

--- a/styles/dxw/tired-idioms.yml
+++ b/styles/dxw/tired-idioms.yml
@@ -1,0 +1,11 @@
+extends: existence
+message: "'%s' is a tired idiom, is it really the best choice of words?"
+level: warning
+ignorecase: true
+code: false
+tokens:
+  - in terms of
+  - look to
+  - with regards to
+  - separate out 
+  - we will aim to

--- a/styles/dxw/words-to-avoid.yml
+++ b/styles/dxw/words-to-avoid.yml
@@ -1,0 +1,8 @@
+extends: substitution
+message: '%s'
+link: https://playbook.dxw.com/#/guides/style-guide
+level: warning
+ignorecase: true
+swap:
+  - platform: Avoid using 'platform', unless it actually is one 
+  - portal: Avoid using 'portal', unless to another dimension

--- a/styles/govuk/words-to-avoid.yml
+++ b/styles/govuk/words-to-avoid.yml
@@ -10,18 +10,18 @@ swap:
   combating: Avoid using 'combating'
   countering: Avoid using 'countering'
   deliver: >
-    Avoid using 'deliver'. Pizzas, post and services are delievered; not abstract concepts like improvements or priorities
+    Avoid using 'deliver'. Pizzas, post and services are delivered; not abstract concepts like improvements or priorities
   deploy: Avoid using 'deploy', unless it's military or software
   dialogue: Avoid using 'dialogue', unless we speak to people 
   disincentivise: Avoid using 'disincentivise'
   empower: Avoid using 'empower'
-  facilitiate: Avoid using 'facilitate', say something specific about how you're helping
+  facilitate: Avoid using 'facilitate', say something specific about how you're helping
   focusing: Avoid using 'focusing'
   foster: Avoid using 'foster', unless it's children 
   impact: Do not use 'impact' as a synonym for have an effect on, or influence 
   initiate: Avoid using 'initiate'
   key: Avoid using 'key', unless it unlocks something
-  land: Only use as 'land' as a verb if you're talking about aircraft 
+  land: Only use 'land' as a verb if you're talking about aircraft 
   leverage: Avoid using 'leverage', unless in the financial sense 
   liaise: Avoid using 'liaise'
   overarching: Avoid using 'overarching'

--- a/styles/govuk/words-to-avoid.yml
+++ b/styles/govuk/words-to-avoid.yml
@@ -1,0 +1,38 @@
+extends: substitution
+message: '%s'
+link: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#words-to-avoid
+level: warning
+ignorecase: true
+swap:
+  agenda: Avoid using 'agenda', unless it's for a meeting 
+  advancing: Avoid using 'advancing'
+  collaborate: Use 'working with' instead of 'collaborate'
+  combating: Avoid using 'combating'
+  countering: Avoid using 'countering'
+  deliver: >
+    Avoid using 'deliver'. Pizzas, post and services are delievered; not abstract concepts like improvements or priorities
+  deploy: Avoid using 'deploy', unless it's military or software
+  dialogue: Avoid using 'dialogue', unless we speak to people 
+  disincentivise: Avoid using 'disincentivise'
+  empower: Avoid using 'empower'
+  facilitiate: Avoid using 'facilitate', say something specific about how you're helping
+  focusing: Avoid using 'focusing'
+  foster: Avoid using 'foster', unless it's children 
+  impact: Do not use 'impact' as a synonym for have an effect on, or influence 
+  initiate: Avoid using 'initiate'
+  key: Avoid using 'key', unless it unlocks something
+  land: Only use as 'land' as a verb if you're talking about aircraft 
+  leverage: Avoid using 'leverage', unless in the financial sense 
+  liaise: Avoid using 'liaise'
+  overarching: Avoid using 'overarching'
+  pledge: Avoid using 'pledge' - we're either doing something or we're not
+  progress: Do not use 'progress' as a verb 
+  promote: Avoid using 'promote', unless you're talking about a marketing promotion 
+  robust: Avoid using 'robust'
+  slimming down: Avoid using 'slimming down', processes do not diet 
+  streamline: Avoid using 'streamline'
+  strengthening: Avoid using 'strengthening', unless it's bridges or other structures 
+  tackling: Avoid using 'tackling', unless it's a sport 
+  transforming: Avoid using 'transforming', what are you actually doing to change it? 
+  utilise: Avoid using 'utilise' 
+  


### PR DESCRIPTION
This uses https://github.com/errata-ai/vale to add prose-linting to the playbook.

It includes custom rules to cover the guidelines outlined in the playbook itself (https://github.com/dxw/playbook/blob/master/guides/style-guide.md) including the list of GOV.UK words to avoid.

There's also some basic checks for offensive terms.

Most of these will trigger warnings rather than errors, to prevent blocking deployment where the usage is legitimate, but a few (e.g. the offensive terms, not using the correct case for `dxw` or terms like `WordPress` & `GovPress`) will cause errors in CI until corrected.