### PR TITLE
Leadership principles in new Professions section

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -618,49 +618,49 @@ At dxw, we believe that great teams need great leaders.
 
 Whether or not they are in a formal management role, leaders at dxw are guided by these principles.
 
-#### 1. Set an example
+#### Set an example
 
 Leaders at dxw demonstrate our values in everything we do. We set high standards of behaviour and inspire both colleagues and clients to do the same.
 
 We demonstrate fairness, integrity, and resilience, and build trust with our actions.
 
-#### 2. Take ownership
-
-Leaders at dxw welcome responsibility and accountability. We’re proactive, pick up things that need doing without being asked and push to finish the job in hand.
-
-We’re the first to admit mistakes, apologise when wrong and learn for next time.
-
-#### 3. Deliver for clients
-
-Leaders at dxw understand how to deliver value for each client and create the conditions for dxw to do brilliant work. We are not afraid to challenge clients or ask difficult questions.
-
-We think commercially and push dxw to grow and strengthen as a business.
-
-#### 4. Provide clarity
-
-Leaders at dxw communicate clearly and concisely through the right channel. We question any decisions, goals or explanations that are vague or ambiguous and work to clarify them.
-
-We’re open, honest and straightforward in what we say and write. And we provide specific, understandable and useful feedback.
-
-#### 5. Make good decisions
-
-Leaders at dxw use evidence and judgement to make good decisions. We know that timely decisions are important, so we don’t procrastinate or fudge. We commit to collective decisions, particularly when we originally disagreed.
-
-We consult broadly, seek out contrary opinions, and listen to quieter voices. We make sure we can explain our decisions, with context, rationale and evidence.
-
-#### 6. Look after people
+#### Look after people
 
 Leaders at dxw promote the wellbeing of individuals, teams and communities. We encourage a supportive culture and inclusive working arrangements. We prioritise 1:1 time with people to listen and understand their particular needs.
 
 We support and defend colleagues in difficult situations. We identify and deal with poor performance and bad behaviour.
 
-#### 7. Point the way
+#### Take ownership
+
+Leaders at dxw welcome responsibility and accountability. We’re proactive, pick up things that need doing without being asked and push to finish the job in hand.
+
+We’re the first to admit mistakes, apologise when wrong and learn for next time.
+
+#### Deliver for clients
+
+Leaders at dxw understand how to deliver value for each client and create the conditions for dxw to do brilliant work. We are not afraid to challenge clients or ask difficult questions.
+
+We think commercially and push dxw to grow and strengthen as a business.
+
+#### Provide clarity
+
+Leaders at dxw communicate clearly and concisely through the right channel. We question any decisions, goals or explanations that are vague or ambiguous and work to clarify them.
+
+We’re open, honest and straightforward in what we say and write. And we provide specific, understandable and useful feedback.
+
+#### Make good decisions
+
+Leaders at dxw use evidence and judgement to make good decisions. We know that timely decisions are important, so we don’t procrastinate or fudge. We commit to collective decisions, particularly when we originally disagreed.
+
+We consult broadly, seek out contrary opinions, and listen to quieter voices. We make sure we can explain our decisions, with context, rationale and evidence.
+
+#### Point the way
 
 Leaders at dxw share an inspiring vision for the future of dxw, and each individual’s part in it.
 
 On client and dxw projects, we make sure that colleagues understand the outcomes we want to achieve and the value that they will create.
 
-#### 8. Build the future
+#### Build the future
 
 Leaders at dxw hire great people. We actively look for the widest range of candidates to strengthen our diversity.
 

--- a/playbook.md
+++ b/playbook.md
@@ -619,41 +619,49 @@ At dxw, we believe that great teams need great leaders.
 Whether or not they are in a formal management role, leaders at dxw are guided by these principles.
 
 #### 1. Set an example
+
 Leaders at dxw demonstrate our values in everything we do. We set high standards of behaviour and inspire both colleagues and clients to do the same.
 
-We demonstrate fairness, integrity, and resilience, and build trust with our actions. 
+We demonstrate fairness, integrity, and resilience, and build trust with our actions.
 
 #### 2. Take ownership
-Leaders at dxw welcome responsibility and accountability. We’re proactive, pick up things that need doing without being asked and push to finish the job in hand. 
+
+Leaders at dxw welcome responsibility and accountability. We’re proactive, pick up things that need doing without being asked and push to finish the job in hand.
 
 We’re the first to admit mistakes, apologise when wrong and learn for next time.
 
 #### 3. Deliver for clients
+
 Leaders at dxw understand how to deliver value for each client and create the conditions for dxw to do brilliant work. We are not afraid to challenge clients or ask difficult questions.
 
 We think commercially and push dxw to grow and strengthen as a business.
 
 #### 4. Provide clarity
+
 Leaders at dxw communicate clearly and concisely through the right channel. We question any decisions, goals or explanations that are vague or ambiguous and work to clarify them.
 
 We’re open, honest and straightforward in what we say and write. And we provide specific, understandable and useful feedback.
 
 #### 5. Make good decisions
+
 Leaders at dxw use evidence and judgement to make good decisions. We know that timely decisions are important, so we don’t procrastinate or fudge. We commit to collective decisions, particularly when we originally disagreed.
 
 We consult broadly, seek out contrary opinions, and listen to quieter voices. We make sure we can explain our decisions, with context, rationale and evidence.
 
 #### 6. Look after people
+
 Leaders at dxw promote the wellbeing of individuals, teams and communities. We encourage a supportive culture and inclusive working arrangements. We prioritise 1:1 time with people to listen and understand their particular needs.
 
 We support and defend colleagues in difficult situations. We identify and deal with poor performance and bad behaviour.
 
 #### 7. Point the way
+
 Leaders at dxw share an inspiring vision for the future of dxw, and each individual’s part in it.
 
 On client and dxw projects, we make sure that colleagues understand the outcomes we want to achieve and the value that they will create.
 
 #### 8. Build the future
+
 Leaders at dxw hire great people. We actively look for the widest range of candidates to strengthen our diversity.
 
 We encourage our colleagues to learn, develop new skills, and pursue their career aspirations, whether at dxw or elsewhere. And we give people opportunity and responsibility at the right pace for them.

--- a/playbook.md
+++ b/playbook.md
@@ -610,6 +610,56 @@ the client and the delivery team to respond quickly to challenges as they arise.
 If priorities change during a sprint, the delivery manager works with the client
 to understand and plan for the impact of the change.
 
+## Professions
+
+### Leadership
+
+At dxw, we believe that great teams need great leaders.
+
+Whether or not they are in a formal management role, leaders at dxw are guided by these principles.
+
+#### 1. Set an example
+Leaders at dxw demonstrate our values in everything we do. We set high standards of behaviour and inspire both colleagues and clients to do the same.
+
+We demonstrate fairness, integrity, and resilience, and build trust with our actions. 
+
+#### 2. Take ownership
+Leaders at dxw welcome responsibility and accountability. We’re proactive, pick up things that need doing without being asked and push to finish the job in hand. 
+
+We’re the first to admit mistakes, apologise when wrong and learn for next time.
+
+#### 3. Deliver for clients
+Leaders at dxw understand how to deliver value for each client and create the conditions for dxw to do brilliant work. We are not afraid to challenge clients or ask difficult questions.
+
+We think commercially and push dxw to grow and strengthen as a business.
+
+#### 4. Provide clarity
+Leaders at dxw communicate clearly and concisely through the right channel. We question any decisions, goals or explanations that are vague or ambiguous and work to clarify them.
+
+We’re open, honest and straightforward in what we say and write. And we provide specific, understandable and useful feedback.
+
+#### 5. Make good decisions
+Leaders at dxw use evidence and judgement to make good decisions. We know that timely decisions are important, so we don’t procrastinate or fudge. We commit to collective decisions, particularly when we originally disagreed.
+
+We consult broadly, seek out contrary opinions, and listen to quieter voices. We make sure we can explain our decisions, with context, rationale and evidence.
+
+#### 6. Look after people
+Leaders at dxw promote the wellbeing of individuals, teams and communities. We encourage a supportive culture and inclusive working arrangements. We prioritise 1:1 time with people to listen and understand their particular needs.
+
+We support and defend colleagues in difficult situations. We identify and deal with poor performance and bad behaviour.
+
+#### 7. Point the way
+Leaders at dxw share an inspiring vision for the future of dxw, and each individual’s part in it.
+
+On client and dxw projects, we make sure that colleagues understand the outcomes we want to achieve and the value that they will create.
+
+#### 8. Build the future
+Leaders at dxw hire great people. We actively look for the widest range of candidates to strengthen our diversity.
+
+We encourage our colleagues to learn, develop new skills, and pursue their career aspirations, whether at dxw or elsewhere. And we give people opportunity and responsibility at the right pace for them.
+
+We continually improve dxw capability, and the effectiveness and efficiency of our delivery. We try out new approaches and technologies and give others the time and space to do the same.
+
 ## Products
 
 ### GovPress


### PR DESCRIPTION
Add a new Professions section between 'Building services' and 'Products'
Add a Leadership section to Professions with the new leadership principles

Once this is merged, I will move the User research section from Building services into Professions