### PR TITLE
(fix) Add basePath so search works correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       repo: '',
       loadNavbar: 'build/partials/_navbar.md',
       homepage: 'playbook.md',
+      basePath: '/',
       maxLevel: 3,
       themeColor: '#006998',
       ga: 'UA-29555961-6',


### PR DESCRIPTION
Recently the search stopped working on the playbook. After looking through similar issues on GitHub it turns out the search function needs a `basePath` now.

Source: https://github.com/docsifyjs/docsify/issues/594