### PR TITLE
Remove our travis linting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,3 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "mdl"
-gem "travis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
-    backports (3.11.4)
-    ethon (0.11.0)
-      ffi (>= 1.3.0)
-    faraday (0.15.4)
-      multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.12.2)
-      faraday (>= 0.7.4, < 1.0)
-    ffi (1.9.25)
-    gh (0.15.1)
-      addressable (~> 2.4.0)
-      backports
-      faraday (~> 0.8)
-      multi_json (~> 1.0)
-      net-http-persistent (~> 2.9)
-      net-http-pipeline
-    highline (1.7.10)
-    json (2.1.0)
     kramdown (1.17.0)
-    launchy (2.4.3)
-      addressable (~> 2.3)
     mdl (0.5.0)
       kramdown (~> 1.12, >= 1.12.0)
       mixlib-cli (~> 1.7, >= 1.7.0)
@@ -29,33 +9,13 @@ GEM
     mixlib-cli (1.7.0)
     mixlib-config (2.2.18)
       tomlrb
-    multi_json (1.13.1)
-    multipart-post (2.0.0)
-    net-http-persistent (2.9.4)
-    net-http-pipeline (1.0.1)
-    pusher-client (0.6.2)
-      json
-      websocket (~> 1.0)
     tomlrb (1.2.7)
-    travis (1.8.9)
-      backports
-      faraday (~> 0.9)
-      faraday_middleware (~> 0.9, >= 0.9.1)
-      gh (~> 0.13)
-      highline (~> 1.6)
-      launchy (~> 2.1)
-      pusher-client (~> 0.4)
-      typhoeus (~> 0.6, >= 0.6.8)
-    typhoeus (0.8.0)
-      ethon (>= 0.8.0)
-    websocket (1.2.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   mdl
-  travis
 
 BUNDLED WITH
    1.16.6

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # script to test the playbook
-echo "=> linting .travis.yml..."
-bundle exec travis lint --no-interactive
 echo "=> linting markdown..."
 if bundle exec mdl -g > /dev/null .
 then


### PR DESCRIPTION
We have a working `.travis.yml` which the linter has issues with.
This causes errors which really don't matter to the users and could
alarm them so we should remove the linter because it is not helping us.