### PR TITLE
Signature lines separated by newline

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -2106,19 +2106,19 @@ is not subject to any specific restrictions.
 
 #### dxw digital
 
-Name
-Job Title
-name@dxw.com
-Twitter handle - if you’re comfortable to share
-Mobile - if you’re comfortable to share
+Name<br>
+Job Title<br>
+name@dxw.com<br>
+Twitter handle - if you’re comfortable to share<br>
+Mobile - if you’re comfortable to share<br>
 
 www.dxw.com :: 0345 2577520 :: @dxw :: creating better digital public services
 
 #### dxw cyber
 
-Name
-Job Title
-name@dxw.com
+Name<br>
+Job Title<br>
+name@dxw.com<br>
 
 www.dxwcyber.com :: 0345 2577520 :: @dxwcyber
 


### PR DESCRIPTION
Markdown isn't very friendly when trying to have new lines start inside the same paragraph.

A simple new line in the source document was not enough, and the words were all mixed into one line, when the intention was that each component of the signature would be on its own line.