### PR TITLE
add Product management principles

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -673,6 +673,68 @@ Findings and recommendations are not the same. Findings mean that ‘we know thi
 **10. Refine outputs and handover**
 These are things like slide decks, user journeys and user needs. We start drafting these early, iterating and adding to them as we go along. We share them frequently ‘just as they are’ so that clients have the opportunity to give us feedback without us spending lots of time making them pixel-perfect. This means we often need to refine part-finished, paper versions of outputs before handing them over to the client as final deliverables. User researchers do the bulk of this work, but it's a team effort. We allocate time before the end of the project to do this and bring in a designer if needed.
 
+### Product management
+
+#### Product management principles
+
+**Set the destination, don’t chart the course**
+Product managers help empower multidisciplinary teams by refining and articulating the problem the team is trying to solve, and the outcomes they’re trying to produce. 
+
+Communicating the vision and goals for a project through a clear and well-maintained roadmap is a core part of product management. 
+
+**Define and defend scope**
+Getting agreement from everyone involved is crucial to successful delivery. 
+
+Product managers should set the direction at the start of a project, and continue to articulate, communicate and defend the scope throughout, so that the team can focus on delivering. 
+
+**Convert insight into action**
+User research helps inform our objectives, goals, and priorities by telling us more about the problems users are having with the current state, or the needs they have for something different. 
+
+Product managers need to be able to balance consider user research insights with constraints like time, capacity, and strategic objectives to prioritise the next most important thing. 
+
+Product managers help the team to work together, across disciplines, to identify potential solutions before choosing a way forward. 
+
+**Have a service mindset**
+Product managers recognise that a digital product is often not the whole solution to a problem, and that the people operating a new service day to day are users too.
+
+We think about the processes and systems around a product, including how those might change. 
+
+**Communicate clearly how the short term outcomes contribute to long term goals**
+Product managers need to own and articulate a vision that is consistent and meaningful to everyone with an interest in the project, from the delivery team all the way through to the most senior stakeholders, and users. 
+
+**Be present, collaborative, and consistent**
+Being available to the team to discuss the unexpected and share in the decision making is central to building empowered and protected teams. 
+
+Product Managers should regularly and actively communicate, review and defend our decisions - especially the unplanned or unexpected ones. 
+
+**Maintain a focus on outcomes**
+In the midst of delivery, key dates can loom large, and teams can be diverted onto things which seem urgent but aren’t important. 
+
+Product managers must help teams and stakeholders remain focused on outcomes over outputs, facilitating discussion and making space for reflection. 
+
+**Lead without authority**
+Product managers shouldn’t be bottlenecks. Product managers and delivery leads work together to build skilled multidisciplinary teams and create the space in which those disciplines can do their best work. 
+
+Product managers are open to new tools, techniques and approaches, working with teams to find what works.
+
+**Take blame, give credit away**
+Good product managers leave their ego at the door, taking negative feedback on board whilst ensuring the team are rightly recognised for their work and achievements. 
+
+Being kind is more important than being right - it’s a good rule of thumb to enter every conversation without assuming that you already know most, or best. 
+
+**Strong opinions, softly held**
+Product managers make the best decisions based on the available information with confidence, staying open to the possibility that things could change when more information is available in the future.
+
+Product managers communicate the trade-offs they’re making and the rationale for their decisions so that teams can understand how a decision was reached, even when they don’t agree. 
+
+**Prioritise** 
+Product managers work with the team, stakeholders and users to define priorities, and ensure these are clear. 
+Measure 
+
+Product managers facilitate and work with service designers and business analyst to work out and key metrics and goals for the product and work with the team to define roadmaps to achieve this goals
+
+h/t to [Ross Ferguson] (https://medium.com/@rossferg/the-principles-that-make-me-a-better-product-manager-9e50814d184f) for inspiring several of these principles 
+
 ## Hosting and supporting services
 
 ### GovPress

--- a/playbook.md
+++ b/playbook.md
@@ -733,7 +733,7 @@ Product managers work with the team, stakeholders and users to define priorities
 **Measure**
 Product managers facilitate and work with service designers and business analysts to work out key metrics and goals for the product and work with the team to define roadmaps to achieve these goals.
 
-h/t to [Ross Ferguson](https://medium.com/@rossferg/the-principles-that-make-me-a-better-product-manager-9e50814d184f) for inspiring several of these principles 
+h/t to [Ross Ferguson](https://medium.com/@rossferg/the-principles-that-make-me-a-better-product-manager-9e50814d184f) for inspiring several of these principles
 
 ## Hosting and supporting services
 

--- a/playbook.md
+++ b/playbook.md
@@ -678,62 +678,62 @@ These are things like slide decks, user journeys and user needs. We start drafti
 #### Product management principles
 
 **Set the destination, don’t chart the course**
-Product managers help empower multidisciplinary teams by refining and articulating the problem the team is trying to solve, and the outcomes they’re trying to produce. 
+Product managers help empower multidisciplinary teams by refining and articulating the problem the team is trying to solve, and the outcomes they’re trying to produce.
 
-Communicating the vision and goals for a project through a clear and well-maintained roadmap is a core part of product management. 
+Communicating the vision and goals for a project through a clear and well-maintained roadmap is a core part of product management.
 
 **Define and defend scope**
-Getting agreement from everyone involved is crucial to successful delivery. 
+Getting agreement from everyone involved is crucial to successful delivery.
 
-Product managers should set the direction at the start of a project, and continue to articulate, communicate and defend the scope throughout, so that the team can focus on delivering. 
+Product managers should set the direction at the start of a project, and continue to articulate, communicate and defend the scope throughout, so that the team can focus on delivering.
 
 **Convert insight into action**
-User research helps inform our objectives, goals, and priorities by telling us more about the problems users are having with the current state, or the needs they have for something different. 
+User research helps inform our objectives, goals, and priorities by telling us more about the problems users are having with the current state, or the needs they have for something different.
 
-Product managers need to be able to balance consider user research insights with constraints like time, capacity, and strategic objectives to prioritise the next most important thing. 
+Product managers need to be able to balance user research insights with constraints like time, capacity, and strategic objectives to prioritise the next most important thing.
 
-Product managers help the team to work together, across disciplines, to identify potential solutions before choosing a way forward. 
+Product managers help the team to work together, across disciplines, to identify potential solutions before choosing a way forward.
 
 **Have a service mindset**
 Product managers recognise that a digital product is often not the whole solution to a problem, and that the people operating a new service day to day are users too.
 
-We think about the processes and systems around a product, including how those might change. 
+We think about the processes and systems around a product, including how those might change.
 
 **Communicate clearly how the short term outcomes contribute to long term goals**
-Product managers need to own and articulate a vision that is consistent and meaningful to everyone with an interest in the project, from the delivery team all the way through to the most senior stakeholders, and users. 
+Product managers need to own and articulate a vision that is consistent and meaningful to everyone with an interest in the project, from the delivery team all the way through to the most senior stakeholders, and users.
 
 **Be present, collaborative, and consistent**
-Being available to the team to discuss the unexpected and share in the decision making is central to building empowered and protected teams. 
+Being available to the team to discuss the unexpected and share in the decision making is central to building empowered and protected teams.
 
-Product Managers should regularly and actively communicate, review and defend our decisions - especially the unplanned or unexpected ones. 
+Product Managers should regularly and actively communicate, review and defend our decisions - especially the unplanned or unexpected ones.
 
 **Maintain a focus on outcomes**
-In the midst of delivery, key dates can loom large, and teams can be diverted onto things which seem urgent but aren’t important. 
+In the midst of delivery, key dates can loom large, and teams can be diverted onto things which seem urgent but aren’t important.
 
-Product managers must help teams and stakeholders remain focused on outcomes over outputs, facilitating discussion and making space for reflection. 
+Product managers must help teams and stakeholders remain focused on outcomes over outputs, facilitating discussion and making space for reflection.
 
 **Lead without authority**
-Product managers shouldn’t be bottlenecks. Product managers and delivery leads work together to build skilled multidisciplinary teams and create the space in which those disciplines can do their best work. 
+Product managers shouldn’t be bottlenecks. Product managers and delivery leads work together to build skilled multidisciplinary teams and create the space in which those disciplines can do their best work.
 
 Product managers are open to new tools, techniques and approaches, working with teams to find what works.
 
 **Take blame, give credit away**
-Good product managers leave their ego at the door, taking negative feedback on board whilst ensuring the team are rightly recognised for their work and achievements. 
+Good product managers leave their ego at the door, taking negative feedback on board whilst ensuring the team are rightly recognised for their work and achievements.
 
-Being kind is more important than being right - it’s a good rule of thumb to enter every conversation without assuming that you already know most, or best. 
+Being kind is more important than being right - it’s a good rule of thumb to enter every conversation without assuming that you already know most, or best.
 
 **Strong opinions, softly held**
 Product managers make the best decisions based on the available information with confidence, staying open to the possibility that things could change when more information is available in the future.
 
-Product managers communicate the trade-offs they’re making and the rationale for their decisions so that teams can understand how a decision was reached, even when they don’t agree. 
+Product managers communicate the trade-offs they’re making and the rationale for their decisions so that teams can understand how a decision was reached, even when they don’t agree.
 
-**Prioritise** 
-Product managers work with the team, stakeholders and users to define priorities, and ensure these are clear. 
-Measure 
+**Prioritise**
+Product managers work with the team, stakeholders and users to define priorities, and ensure these are clear.
 
-Product managers facilitate and work with service designers and business analyst to work out and key metrics and goals for the product and work with the team to define roadmaps to achieve this goals
+**Measure**
+Product managers facilitate and work with service designers and business analysts to work out key metrics and goals for the product and work with the team to define roadmaps to achieve these goals.
 
-h/t to [Ross Ferguson] (https://medium.com/@rossferg/the-principles-that-make-me-a-better-product-manager-9e50814d184f) for inspiring several of these principles 
+h/t to [Ross Ferguson](https://medium.com/@rossferg/the-principles-that-make-me-a-better-product-manager-9e50814d184f) for inspiring several of these principles 
 
 ## Hosting and supporting services
 

--- a/playbook.md
+++ b/playbook.md
@@ -727,10 +727,10 @@ Product managers make the best decisions based on the available information with
 
 Product managers communicate the trade-offs they’re making and the rationale for their decisions so that teams can understand how a decision was reached, even when they don’t agree.
 
-**Prioritise**
+**Set clear priorities**
 Product managers work with the team, stakeholders and users to define priorities, and ensure these are clear.
 
-**Measure**
+**Measure outcomes**
 Product managers facilitate and work with service designers and business analysts to work out key metrics and goals for the product and work with the team to define roadmaps to achieve these goals.
 
 h/t to [Ross Ferguson](https://medium.com/@rossferg/the-principles-that-make-me-a-better-product-manager-9e50814d184f) for inspiring several of these principles


### PR DESCRIPTION
this pull request adds the product community's principles to the playbook. It doesn't currently add an introductory 'we believe' statement - this can be added later in a separate pull request to be consistent with the principles for other professions, when the team has had a chance to think about what it should say.