### PR TITLE
(chore) Fix Blog section header

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -2245,7 +2245,9 @@ advice or time to prepare, don't be afraid to ask for it. It's also good to blog
 after the event, to talk about your experience and what you learned. If you need
 time to be set aside, talk to a Delivery Manager and see what's possible.
 
-### Blog At dxw, we all write blog posts regularly
+### Blog
+
+At dxw, we all write blog posts regularly.
 
 We blog because want to share what we're doing and what we're learning about
 tech and government with the digital community. When we're hiring, we also want


### PR DESCRIPTION
This section header - `Blog At dxw, we all write blog posts regularly` - seemed wrong. I think it should be a section header + first line.

<img width="712" alt="screenshot 2019-02-08 at 15 28 50" src="https://user-images.githubusercontent.com/1089521/52487863-7b0cf600-2bb6-11e9-828b-854fd864f207.png">

<img width="357" alt="screenshot 2019-02-08 at 15 27 37" src="https://user-images.githubusercontent.com/1089521/52487872-7ea07d00-2bb6-11e9-806a-62b7973471a8.png">
