### PR TITLE
Help teams understand people

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -686,7 +686,7 @@ At dxw, we believe in making decisions based on evidenced user needs. As user re
 
 Our principles are not rules. They guide our work, keep us improving as a team, and working with, not for our clients.
 
-1. **Help teams understand their users**
+1. **Help teams understand people**
 
    Researchers at dxw help our teams build a deep understanding of the people who use our services. We know that‘s the best way to create public services that work well for the people who need them.
 


### PR DESCRIPTION
"... understand their users" is clumsy, but "... understand users" isn't right either.
One draft had "... understand users as people" but that's even clumsier.
"... understand people" is simple and clear.