### PR TITLE
Remove an unclear possibly prejudicial line from Screening criteria

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -1601,9 +1601,7 @@ qualities than about skills. Things to keep in mind:
 
 * Does this person seem likely to embody our [values](#values)?
 * Does this person have an interest in our [mission](#why-are-we-all-here)?
-* Does this person have experience working in [agile environments](#agile-mindset)
-* Would you be comfortable taking this person to a meeting with a client?
-  If not, why not?
+* Does this person have experience working in [agile environments](#agile-mindset)?
 
 If you can find out how they heard about the job, that's useful for us to know.
 


### PR DESCRIPTION
Discussed with @vanessa-w.

When I was applying, this line made me very uncomfortable. It
doesn't give any guidance on what the requirements are. This is
probably one of the first sections a potential candidate might
read, and it might put of some of the more diverse applicants from
applying.