### PR TITLE
(fix) Explicitly tell the search to look at the root path

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,9 @@
       themeColor: '#006998',
       ga: 'UA-29555961-6',
       formatUpdated: '{DD}/{MM}/{YY}',
-      search: 'auto',
+      search: {
+        paths: ['/']
+      },
       plugins: [
         EditOnGithubPlugin.create(
           'https://github.com/dxw/playbook/blob/master/',


### PR DESCRIPTION
When setting the 'auto' search mode with our current set up it will break the search feature.

Since most of the searches will be on the main playbook I think this will be ok. It means that search won't look for anything on the guides. The alternative is to turn search off or replace Docsify.