### PR TITLE
Add a section on versioning releases to the development guide

### DIFF
--- a/guides/development-workflow.md
+++ b/guides/development-workflow.md
@@ -480,7 +480,7 @@ A new registration form and fix a bug with contacts
 
 We don't use explicit versioning for frontend projects; rather we operate a continuous deployment approach as described in the [deploying](#deploying) section.
 
-However, when building libraries, APIs, or other software components designed for reuse, versioning is important. All reusable components should have properly versioned releases. This includes Wordpress plugins and themes, ruby gems, and so on, whether open source or otherwise.
+However, when building libraries, APIs, or other software components designed for reuse, versioning is important. All reusable components should have properly versioned releases. This includes Wordpress plugins and themes, Ruby gems, and so on, whether open source or otherwise.
 
 Versioning should follow the [Semantic Versioning](https://semver.org) standard, and projects that use them should specify their requirements so that the appropriate versions are used.
 

--- a/guides/development-workflow.md
+++ b/guides/development-workflow.md
@@ -478,7 +478,7 @@ A new registration form and fix a bug with contacts
 
 ## Versioning releases
 
-We don't use explicit versioning for frontend projects; rather we operate a continuous deployment approach as described in the [deploying](#deploying) section.
+We don't use explicit versioning for application code; rather we operate a continuous deployment approach as described in the [deploying](#deploying) section.
 
 However, when building libraries, APIs, or other software components designed for reuse, versioning is important. All reusable components should have properly versioned releases. This includes Wordpress plugins and themes, Ruby gems, and so on, whether open source or otherwise.
 

--- a/guides/development-workflow.md
+++ b/guides/development-workflow.md
@@ -10,6 +10,7 @@
 - [Code review](#code-review)
 - [Code style](#code-style)
 - [Pull requests](#pull-requests)
+- [Versioning releases](#versioning-releases)
 
 ## Introduction
 
@@ -474,3 +475,19 @@ A new registration form and fix a bug with contacts
 - Passwords are encrypted using BCrypt, so I've taken this opportunity to
   increase the default rounds from 8 to 12
 ```
+
+## Versioning releases
+
+We don't use explicit versioning for frontend projects; rather we operate a continuous deployment approach as described in the [deploying](#deploying) section.
+
+However, when building libraries, APIs, or other software components designed for reuse, versioning is important. All reusable components should have properly versioned releases. This includes Wordpress plugins and themes, ruby gems, and so on, whether open source or otherwise.
+
+Versioning should follow the [Semantic Versioning](https://semver.org) standard, and projects that use them should specify their requirements so that the appropriate versions are used.
+
+Releases should be created by:
+
+- updating the version appropriately in package metadata and committing to git
+- tagging that commit using a tag of the form `vX.Y.Z`
+- building the appropriate release package from that tag
+
+Software that has not previously been versioned, but has already been used in production, should start at version `v1.0.0`.

--- a/guides/development-workflow.md
+++ b/guides/development-workflow.md
@@ -489,5 +489,3 @@ Releases should be created by:
 - updating the version appropriately in package metadata and committing to git
 - tagging that commit using a tag of the form `vX.Y.Z`
 - building the appropriate release package from that tag
-
-Software that has not previously been versioned, but has already been used in production, should start at version `v1.0.0`.


### PR DESCRIPTION
So that we can predictably update code that uses them, software designed for reuse (wordpress, gems, etc) should be properly versioned.