### PR TITLE
Remove the convention of using prefixes for commits

### DIFF
--- a/guides/development-workflow.md
+++ b/guides/development-workflow.md
@@ -339,23 +339,6 @@ Ask yourself these questions:
 - have I written down **why** I chose this approach over the others?
 - are there relevant links I could include to help the next person?
 
-### Convention
-
-To help us focus on the contents of our commits and convey concise messages to
-the reader we use a handful of prefixes. These allow us to move fast when
-reading through code because we can understand each commit's purpose without
-risk of misinterpreting the title.
-
-It is a powerful tool for a developer to read a commit that starts with
-`(refactor)` and trust that no new behaviour was added.
-
-```
-(feature) when we are adding something new
-(fix) when we are fixing something existing
-(refactor) when we aren’t changing functionality
-(chore) catch all for when none of the above apply
-```
-
 ### Examples
 
 ```
@@ -363,7 +346,7 @@ It is a powerful tool for a developer to read a commit that starts with
 Added repairs
 
 # Great
-(feature) Job postings are now displayed on the landing page
+Job postings are now displayed on the landing page
 
 - Getting the Job postings out of the external API proved difficult but I think
   the solution we have will allow us to easily upgrade to the new release they
@@ -375,7 +358,7 @@ Added repairs
 Fixed the form
 
 # Great
-(fix) Food order form works with special characters
+Food order form works with special characters
 
 - Previously the form failed to send if the starter value included any of the
   following characters: `!@£$%^&`
@@ -390,7 +373,7 @@ Fixed the form
 Gem upgrade
 
 # Great
-(chore) Upgrade widget to v1.2.1
+Upgrade widget to v1.2.1
 
 - This widget now includes a patch that improves resilience: <link>
 - We are still unable to upgrade to v2.x as we need to do some migration work


### PR DESCRIPTION
In a tech team meeting (2019-09-06) we discussed if using prefixes on commits was
still a good idea. We decided that it wasn't.

We are inconsistent with our use of them and contractors don't
necessarily follow our conventions.

We felt it was still useful to keep the branch naming convention.