### PR TITLE
Update compressed hours policy

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -1718,7 +1718,7 @@ We are happy to have a discussion about compressed hours for internal-facing rol
 
 35 hours in 3 days, for example, is a no across all roles. It goes against our encouragement of [sustainable pace](#sustainable-pace).
 
-To address annual leave and bank holidays – a holiday day is 7 hours, so holiday entitlement should be considered as 175 hours and split accordingly given the compressed working day is 8 hours 45 minutes. We prefer that no member of the team should work on a bank holiday and the non working day be scheduled as such.
+For working patterns with the same number of hours each day, holiday allowance can be treated the same as for [part-time roles](#part-time-working). For working patterns with varied hours, the annual allowance for both holiday and bank holidays should be counted in hours (231 hours per year) and bank holidays that fall on working days must be booked as leave.
 
 #### Remote working/location
 

--- a/playbook.md
+++ b/playbook.md
@@ -1710,7 +1710,11 @@ Salary and holiday allowances would remain the same.
 
 #### Compressed hours
 
-If you’d like to work compressed hours, for example; 35 hours in 4 days, 9.30am–6.45pm we would support a discussion for both internal facing roles and client facing roles but cannot guarantee this would be an option. The latter would require further consideration due to the impact on active synchronous collaboration.
+Compressed hours involves working your full hours in fewer days. For example: 35 hours in 4 days, 9.30am–6.45pm.
+
+We don't offer compressed hours for client-facing roles due to the complications for the way we bill our time and present our services to clients.
+
+We are happy to have a discussion about compressed hours for internal-facing roles but cannot guarantee this would be an option.
 
 35 hours in 3 days, for example, is a no across all roles. It goes against our encouragement of [sustainable pace](#sustainable-pace).
 


### PR DESCRIPTION
Update the compressed hours policy to rule it out for client-facing roles.

This question came up recently, and after discussion with the directors we concluded we are not happy to offer compressed hours for roles where people are billed most of the time.

Details in the text and commit message.

The second commit is tidying up the language for the way holiday allowance works for compressed hours. If it doesn't actually make things better, or is in any way controversial, I'm happy to drop it from this PR – the main thing is updating the docs to reflect our actual position.