### PR TITLE
Trigger actions when pull request is opened

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,5 +1,5 @@
 name: Linting
-on: [push]
+on: [push, pull_request]
 
 jobs:
   prose:


### PR DESCRIPTION
It seems that if a user adds/edits a page via the web interface, actions don't get run. I've added the `pull_request` action, which should mitigate this