### PR TITLE
explainer for design career progression framework

### DIFF
--- a/guides/designers-career-progression-framework.md
+++ b/guides/designers-career-progression-framework.md
@@ -1,0 +1,66 @@
+# Designers’ career progression framework
+
+## Why do we have a career progression framework?
+
+Not knowing if progression can ever happen for you, or if it always feels out of reach, or if you feel as though your growth isn’t translating into something that’s recognised, it can be demoralising. You should see a clear pathway, visible opportunities to progress, and the benefits of each level of progression laid out plainly.
+
+After your progression review, you should be able to clearly identify areas for improvement. Your line manager can work with you in a subsequent 1:1 to help create a plan of action to achieve your goals.
+
+Having a framework helps us to ensure a more level playing field for all. We can eliminate bias by mapping progression to objective criteria instead of time served, negotiation skills, age, gender etc.
+
+A framework helps get open consensus between you and your manager on your level of progression; any ambiguity, or an unexpressed gap between your opinions on your level, could lead to disappointment.
+
+If your manager was to suddenly disappear into thin air, your progress should not disappear with them. A framework keeps a record of this information.
+
+## How will it work?
+
+The framework measures progression through a set of proficiencies, against levels of progress.
+
+There are six areas of proficiency:
+
+- Design
+- Technical
+- Communication
+- Delivery
+- Empathy
+- Leadership
+
+And there are currently four levels of progression:
+
+- Designer level 1
+- Designer level 2
+- Designer level 3
+- Designer level 4
+
+Note: these are not roles, or titles — those remain “Designer”, and “Senior Designer”. It is important to note that you do not need to be at level 4 to progress to a Senior Designer. Each criterion indicates at what level is required to become a Senior Designer.
+
+Progress from one level to the next relies on a designer demonstrating proficiency in all its areas. These levels are mapped to salaries.
+
+We’ll extend the framework to cover junior designers when we make our first hire in that role. We’ll also look at adding level above 4 when we appoint seniors.
+
+## Progression doesn’t have to mean becoming a manager
+
+Doing line management is not a requirement for progression at dxw. To deliver great work for our clients we need great practitioners; to build an effective team and business we need great managers.
+
+There is some overlap between practitioner and manager at the senior level, where we have expectations of mentoring and teaching. Requiring a designer to take on line management responsibilities in order to progress to a senior role could result in them growing to resent the responsibility, and worse, in the person that designer is line managing being completely under-served.
+
+Getting up and running won’t be straightforward, but we’ll be designing people’s careers — not just for those here now, but for those to join in the future.
+
+## Tracking progression
+
+At regular intervals throughout the year, your usual 1:1 with your manager will be substituted for a meeting where together you’ll review your progression as measured against the framework. These meetings will be scheduled for 90 minutes. These meetings can be quite intensive, so we’ll have the opportunity for a half-time break.
+
+In these meetings you’ll choose with your manager the proficiencies you’d like to concentrate on over the following three months. Narrowing it down to a handful will enable you to focus more deeply on each proficiency.
+We’ll also occasionally look retrospectively at levels of proficiency you’ve already achieved, to make sure they’re still an active element in your day-to-day work.
+
+## The Framework
+
+The framework content – levels and proficiencies – is kept as a single-source-of-truth in a Google Sheet (shared internally at dxw only, for now).
+
+Every member of the team also has their own Sheet, with a tab dated for each formal review, for tracking progression and gathering examples for review meetings.
+
+It’s entirely down to team members how they gather examples to use as discussion pieces for review meetings. You might use Google Docs or Sheets, or Trello, or Miro. Whatever works best for you is fine, but you will need to be able to paste links to whatever you’ve collected into your tracking GSheet at review time.
+
+## Where did the framework come from?
+
+We’ve borrowed from others who’ve got established frameworks, and added our own dxw specifics. Our framework borrows elements and approaches from those in use at places such as Clearleft, Monzo, Buzzfeed, the Financial Times, and GDS. It’s then been refined and customised to suit how we actually work and practice design at dxw.


### PR DESCRIPTION
Adding a guide to the playbook for the design career progression framework. Just the basics for now and very much subject to change as we learn more about what works and what needs improving.