### PR TITLE
Create team-and-project-scheduling section

### DIFF
--- a/guides/team-and-project-scheduling
+++ b/guides/team-and-project-scheduling
@@ -1,0 +1,67 @@
+# Team and project scheduling
+
+***If there are any questions about anything mentioned in this guide, put a message in the #scheduling slack channel - most people in this channel have a good level of knowledge of 10kft and should be able to offer clarification.***
+
+- [What we use 10kft for and why](## What we use 10kft for and why)
+ 
+## What we use 10kft for and why
+
+### Forecasting for sales
+Our sales team secure us new work, and so need to be able to use 10kft to understand team availability and capacity. They also need to know the skill shapes we have available. This helps us to match people to projects.**
+
+### Scheduling work
+
+We use 10kft to schedule client work, across all three business units: delivery, strategy and technical operations. The scheduling team, a combination of sales, delivery and strategy team members, meet weekly to talk through team availability and the gaps we have in our schedule. Actions and decisions are noted in the #scheduling slack channel.
+
+*There are many aspects to scheduling, these predominantly are:*
+
+1.  future work we could win
+2.  current work being extended or amended
+3.  team shape changing
+
+Before the weekly scheduling meeting, 10kft should reflect:
+
+-   project needs: changes to existing projects
+-   sales needs: confirmed and potential new work
+
+Before each weekly meeting, the person responsible for the project or new sales lead ensures 10kft is updated. We use placeholders to reflect needs.
+
+During the meeting we use these placeholders to have discussions around the needs of the project: what the skill shape is and whether that matches up with the gaps in the schedule and the team members we have available.
+
+We base our scheduling conversation around placeholders. If a project or sales need isn’t added ahead of the scheduling meeting, it could be another week before needs are discussed.
+
+Tentative placeholders then get reassigned during the meeting once confirmed.
+
+### Sales opportunities - a bit more detail
+
+Tentative placeholders should be added to 10ft as soon as an opportunity reaches the pitch stage of a bid, to be discussed at scheduling.
+
+Each sales opportunity has a “sales lead”. This person is responsible for coming to scheduling to give the latest update and share the likelihood of a win, so we can assess against a project needing a similar skill set. This is compulsory. We undermine our own process if we do not have the latest information.
+
+The **sales lead** should:
+
+-   describe and explain the new opportunity in the #scheduling slack channel. Including nature of work, proposed team shape, possible scheduling challenges & potential start date
+-   add a tentative placeholder to 10kft. Go to the “How to…” sections for details of how to do this
+-   leave notes in scheduling channel with latest information
+  
+Once a sales opportunity is realised, this is handed over to the “project lead”, assigned to that work.
+
+The **project lead** should:
+
+-   ensure all tentative placeholders are accurate in 10kft    
+-   speak with the team assigned to the work to discuss next steps
+-   review and amend where needed the project set up in 10kft
+
+### Reporting our time
+
+Every team member working on a client or named project is responsible for reporting their time, as mentioned [here](http://playbook.dxw.com/#/?id=reporting-our-time) in the playbook. More on how to do this in the “how to” section.
+
+### Reporting against the business plan
+
+Every month, we use the data reported in 10kft to understand things like billing and utilisation numbers. This helps us see if we’re where we thought we’d be, if this matches up to our projections and if not, why.  
+
+Some reasons why this is helpful for us as a business:
+
+-   It helps us understand if we need to schedule more work or if we’re over capacity. This means we can better predict if we need to grow the team or take a pause on recruitment.
+-  We can see who is free for dxw days. So we can use this information to try and schedule/plan an internal project. Especially useful if this is not on a Friday.    
+-   Similarly, we can use this information in compiling reports to reflect the value of dxw days.

--- a/guides/team-and-project-scheduling.md
+++ b/guides/team-and-project-scheduling.md
@@ -14,8 +14,8 @@ We use 10kft to schedule client work, across all three business units: delivery,
 *There are many aspects to scheduling, these predominantly are:*
 
 1.  future work we could win
-2.  current work being extended or amended
-3.  team shape changing
+1.  current work being extended or amended
+1.  team shape changing
 
 Before the weekly scheduling meeting, 10kft should reflect:
 

--- a/guides/team-and-project-scheduling.md
+++ b/guides/team-and-project-scheduling.md
@@ -1,13 +1,11 @@
 # Team and project scheduling
 
 ***If there are any questions about anything mentioned in this guide, put a message in the #scheduling slack channel - most people in this channel have a good level of knowledge of 10kft and should be able to offer clarification.***
-
-- [What we use 10kft for and why](## What we use 10kft for and why)
  
 ## What we use 10kft for and why
 
 ### Forecasting for sales
-Our sales team secure us new work, and so need to be able to use 10kft to understand team availability and capacity. They also need to know the skill shapes we have available. This helps us to match people to projects.**
+Our sales team secure us new work, and so need to be able to use 10kft to understand team availability and capacity. They also need to know the skill shapes we have available. This helps us to match people to projects.
 
 ### Scheduling work
 
@@ -54,7 +52,7 @@ The **project lead** should:
 
 ### Reporting our time
 
-Every team member working on a client or named project is responsible for reporting their time, as mentioned [here](http://playbook.dxw.com/#/?id=reporting-our-time) in the playbook. More on how to do this in the “how to” section.
+Every team member working on a client or named project is responsible for reporting their time, as mentioned [in the playbook](http://playbook.dxw.com/#/?id=reporting-our-time). More on how to do this in the “how to” section.
 
 ### Reporting against the business plan
 

--- a/guides/team-and-project-scheduling.md
+++ b/guides/team-and-project-scheduling.md
@@ -1,15 +1,24 @@
 # Team and project scheduling
 
-***If there are any questions about anything mentioned in this guide, put a message in the #scheduling slack channel - most people in this channel have a good level of knowledge of 10kft and should be able to offer clarification.***
+***If anything in this guide is unclear, put a message in the #scheduling slack channel - most people in this channel have a good level of knowledge of 10kft and should be able to offer clarification. We can then make an update to this guide.***
+
+This guide can be used to find out what 10kft is for, as well as called upon when we’re not sure how to do something, as a team member, scheduler or administrator of 10kft. This guide is split into sections depending on the audience, to help navigate. We've defined the audience as:
+
+**Team members:** all team members assigned to projects
+
+**Schedulers:** mostly project leads (in delivery, product or strategy) or sales leads
+
+**Admins:** mostly project leads and the commercial team
  
 ## What we use 10kft for and why
 
 ### Forecasting for sales
-Our sales team secure us new work, and so need to be able to use 10kft to understand team availability and capacity. They also need to know the skill shapes we have available. This helps us to match people to projects.
+
+Our sales team secure us new work. They need to be able to use 10kft to understand team availability and capacity. They also need to know the skill shapes we have available. This helps us to match people to projects.
 
 ### Scheduling work
 
-We use 10kft to schedule client work, across all three business units: delivery, strategy and technical operations. The scheduling team, a combination of sales, delivery and strategy team members, meet weekly to talk through team availability and the gaps we have in our schedule. Actions and decisions are noted in the #scheduling slack channel.
+We use 10kft to schedule client work, across all three business units: delivery, strategy and technical operations. The scheduling team meet weekly to talk through team availability and the gaps we have in our schedule. Actions and decisions are noted in the #scheduling slack channel.
 
 *There are many aspects to scheduling, these predominantly are:*
 
@@ -17,49 +26,335 @@ We use 10kft to schedule client work, across all three business units: delivery,
 1.  current work being extended or amended
 1.  team shape changing
 
-Before the weekly scheduling meeting, 10kft should reflect:
+Before the weekly scheduling meeting, 10kft must reflect:
 
 -   project needs: changes to existing projects
 -   sales needs: confirmed and potential new work
 
-Before each weekly meeting, the person responsible for the project or new sales lead ensures 10kft is updated. We use placeholders to reflect needs.
+Before each scheduling meeting, the project lead or sales lead ensures 10kft is updated. We use placeholders to reflect needs.
 
-During the meeting we use these placeholders to have discussions around the needs of the project: what the skill shape is and whether that matches up with the gaps in the schedule and the team members we have available.
+During the meeting we use placeholders to have discussions around the needs of projects: what the skill shape is and whether that matches up with gaps in our schedule and the team members that are available.
 
-We base our scheduling conversation around placeholders. If a project or sales need isn’t added ahead of the scheduling meeting, it could be another week before needs are discussed.
+We base our scheduling conversation around placeholders. If a project or sales need isn’t added ahead of the scheduling meeting, it might be another week before needs are discussed.
 
-Tentative placeholders then get reassigned during the meeting once confirmed.
+Placeholders get assigned and confirmed during the scheduling meeting.
 
-### Sales opportunities - a bit more detail
+### Sales opportunities
 
-Tentative placeholders should be added to 10ft as soon as an opportunity reaches the pitch stage of a bid, to be discussed at scheduling.
+Tentative placeholders must be added to 10ft as soon as an opportunity reaches the pitch stage.
 
-Each sales opportunity has a “sales lead”. This person is responsible for coming to scheduling to give the latest update and share the likelihood of a win, so we can assess against a project needing a similar skill set. This is compulsory. We undermine our own process if we do not have the latest information.
+Each sales opportunity has a “sales lead”. This person is responsible for attending scheduling meetings to give the latest update and share the likelihood of a win. This is so we can assess against a project that requires similar skill sets. This is compulsory. We undermine our own process if we do not have the latest information.
 
 The **sales lead** should:
 
--   describe and explain the new opportunity in the #scheduling slack channel. Including nature of work, proposed team shape, possible scheduling challenges & potential start date
--   add a tentative placeholder to 10kft. Go to the “How to…” sections for details of how to do this
--   leave notes in scheduling channel with latest information
+-   describe and explain new opportunities in the #scheduling slack channel. Including the nature of work, proposed team shape and start dates, along with any scheduling challenges
+-   add tentative placeholders to 10kft (go to the [adding a placeholder](http://playbook.dxw.com/#/guides/team-and-project-scheduling?id=adding-a-placeholder) section of this guide for details on how to do this)
+-   leave notes in the #scheduling channel with the latest information
   
-Once a sales opportunity is realised, this is handed over to the “project lead”, assigned to that work.
+Once a sales opportunity is realised, this is handed over to a “project lead”, assigned to that work.
 
 The **project lead** should:
 
 -   ensure all tentative placeholders are accurate in 10kft    
 -   speak with the team assigned to the work to discuss next steps
--   review and amend where needed the project set up in 10kft
+-   review the project set up in 10kft and amend where needed 
 
 ### Reporting our time
 
-Every team member working on a client or named project is responsible for reporting their time, as mentioned [in the playbook](http://playbook.dxw.com/#/?id=reporting-our-time). More on how to do this in the “how to” section.
+Every team member working on a client or named project is responsible for reporting their time, as mentioned [in the playbook](http://playbook.dxw.com/#/?id=reporting-our-time). More on how to do this in the [reporting time](http://playbook.dxw.com/#/guides/team-and-project-scheduling?id=reporting-time) section of this guide.
 
 ### Reporting against the business plan
 
-Every month, we use the data reported in 10kft to understand things like billing and utilisation numbers. This helps us see if we’re where we thought we’d be, if this matches up to our projections and if not, why.  
+We use data reported in 10kft to help us understand if we’re where we thought we’d be and if this matches up to our projections. 
 
-Some reasons why this is helpful for us as a business:
+Some reasons why this is helpful for us as a business are:
 
--   It helps us understand if we need to schedule more work or if we’re over capacity. This means we can better predict if we need to grow the team or take a pause on recruitment.
--  We can see who is free for dxw days. So we can use this information to try and schedule/plan an internal project. Especially useful if this is not on a Friday.    
--   Similarly, we can use this information in compiling reports to reflect the value of dxw days.
+- it helps us understand if we need to schedule more work or if we’re over capacity (this means we can better predict if we need to grow the team or take a pause on recruitment)
+- we can see who is free for dxw days, so that we can use this information to plan for internal projects
+- similarly, we can use this information in compiling reports to reflect the value of dxw days
+
+## Intended Audience - a Scheduler
+
+### Adding a placeholder
+
+A project will need to exist in order to assign a placeholder for it. If a project hasn’t been added yet, go to the [adding a project](http://playbook.dxw.com/#/guides/team-and-project-scheduling?id=adding-a-new-project) section of this guide. Return here once the project has been added.
+
+To assign a placeholder, go to the schedule view of 10kft, via the navigation bar. The schedule will need to be filtered under ‘Everyone’.
+
+![Image of 10kft schedule view](http://playbook.dxw.com/guides/Image%20of%2010kft%20schedule%20view.png)
+
+Scroll to the bottom of the schedule view, where there will be a list of placeholder role types.
+
+![Image of 10kft schedule placeholder view](http://playbook.dxw.com/guides/Image%20of%2010kft%20schedule%20placeholder%20view.png)
+
+Click on a space that is relevant to the placeholder and select ‘New Assignment’. For example, service designer in the week commencing would look something like: 
+
+![Image of 10kft schedule view new assignment](http://playbook.dxw.com/guides/Image%20of%2010kft%20schedule%20view%20new%20assignment.png)
+
+Search for a project via the search bar.
+
+![Image of 10kft schedule view placeholder search](http://playbook.dxw.com/guides/Image%20of%2010kft%20schedule%20view%20placeholder%20search.png)
+
+Select the project that the placeholder needs to be assigned to. Once a placeholder has been created, project details can be adjusted by clicking on the newly entered placeholder. A pop up for adjustments will look like this:
+
+![Image of 10kft placeholder adjustment options](http://playbook.dxw.com/guides/Image%20of%2010kft%20placeholder%20adjustment%20options.png)
+
+This will need to be done for all roles within a project that need to be scheduled.
+
+## Intended Audience - Team members
+
+### Reporting time
+
+Every team member working on a client or named internal project is responsible for reporting their time. For guidance on this, visit the [reporting our time](http://playbook.dxw.com/#/?id=reporting-our-time) section of the playbook. For how to do this, see the step by step below.
+
+### Step by Step 
+
+Click on your name in the top banner of 10kft. Then click on the “Time & Expenses” tab as seen below.
+
+![Image of 10kft time and expenses tab](http://playbook.dxw.com/guides/Image%20of%2010kft%20time%20and%20expenses%20tab.png)
+
+If the projected time on a project is correct, select the ‘confirm’ button to report the time. Time is recorded in the number of hours per day - this could be a full or a half day.
+
+![Image of unconfirmed time in 10kft](http://playbook.dxw.com/guides/Image%20of%20unconfirmed%20time%20in%2010kft.png)
+
+Once confirmed the view will become **bold**, with a tick:
+
+![Image of confirmed time in 10kft](http://playbook.dxw.com/guides/Image%20of%20confirmed%20time%20in%2010kft.png)
+
+If what was worked on isn’t shown, click on the 'Report Time for Something Else' option, to search and find the project that’s been worked on. If this happens, make it known to the project lead. 
+
+![Image of time tracking option in 10kft](http://playbook.dxw.com/guides/Image%20of%20time%20tracking%20option%20in%2010kft.png)
+
+## Intended Audience - Admins
+
+### Reporting a contractors time
+
+Contractors are added for purposes of utilisation and billing. **Contractors do not have their own access to 10kft.** Project leads are responsible for confirming the contractor's time.
+
+A contractor’s time on a client project must be reported and confirmed. Just like when reporting and confirming our own time on client work. Only Admins of 10kft can confirm a contractor's time. All project leads will have admin access.
+
+To report a contractor’s time, search their name in 10kft. If there’s a contractor working on a team, but are not yet represented in 10kft, go to the [setting up an account](http://playbook.dxw.com/#/guides/team-and-project-scheduling?id=setting-up-an-account) section of this guide. 
+
+### Adding a new team member
+
+Not everyone at dxw needs access to 10kft, so we use our judgement as to who should have an account. The rule of thumb is, if someone is on billed client work or they need to see when teams become available or understand our financial reporting, they should have an account.
+
+#### dxw digital is made up of three core functions
+
+These functions are delivery, strategy and technical operations. Generally all team members are set up in a similar way, with project and people tags, as well as target utilisation, which varies per team member. 
+
+### Who sets up access?
+
+Setting up access to 10kft is part of our onboarding procedure. New team members are set up by the Commercial Operations team. Contractors are typically added - ***with restricted access*** - by the Commercial Operations team, at the point of a new work outline being signed.
+
+#### If you think you need an account but don’t have one
+
+If an account is needed, talk to a project lead, or send a message in the #dxw-toolsandsubscriptions slack channel for the Commercial Operations team to pick up.
+
+### Who are the users?
+
+The delivery, strategy and technical operations team members. As well as members of our sales and commercial operations team.
+
+### Which function does a team member sit within?
+
+When referencing the delivery, strategy or technical operations teams, we mean multiple disciplines working under one of three functions at dxw digital. 
+
+Team members who work within the **delivery function**, sit within one of the following disciplines:
+
+- delivery lead
+- product manager
+- developer
+- technical architect
+- designer
+- researcher
+
+Team members who work within the **strategy function**, sit within one of the following disciplines:
+
+- transformation lead
+- service designer
+
+Team members who work within the **technical operations function**, sit within the following discipline:
+
+- operations engineer
+
+### Setting up an account
+
+When signed in to 10kft, go to ‘Settings’ (located at the top right of the screen), select ‘Account Settings’ in the dropdown. Access to the admin panel should then be enabled, which allows adding a new team member. If admin access isn't enabled, raise this in the #toolsandsubscriptions slack channel.
+
+By selecting ‘People’ in the left hand column of the admin panel, a list of all team members will become visible. To add a new team member, select ‘Add Person’
+
+Select ‘Add Licensed User’. To see the full account set up, click ‘Show more’. This view is needed to be able to allocate the correct settings for team members.
+
+Note: We add contractors who are employed by dxw as ‘licensed users’. *We don’t provide contractors with access to sign in, but the account must be set up as a licensed account, so that we can track their time*.
+
+A page similar to this image will be visible. This section is a walk through of how to set up a team member correctly, based on their role, permission level and availability.
+
+![Image of setting up an account in 10kft](http://playbook.dxw.com/guides/Image%20of%20setting%20up%20an%20account%20in%2010kft.png)
+
+#### If the team member is a permanent employee of dxw
+
+The following information needs to be set:
+
+- first and last name
+- a dxw email address
+- home office location (this will either be Hoxton or Leeds - if the team member is a remote worker, they should always have at least one home office location)
+
+We ignore the input fields for phone numbers and employee codes - this information isn’t something we record in 10kft.
+
+#### If the team member is a contractor, working with dxw 
+
+Setting up a contractor account must be done by the commercial team, at the point of receiving a signed work outline.
+
+If we've worked with the contractor before, they may already have an account in 10kft. Check the archived accounts list to re-activate the account. If not, the following information needs to be set:
+
+- first and last name
+- home office location (this will either be Hoxton or Leeds - if the team member is a remote worker, they should always have at least one home office location)
+- permission level, set as 'contractor'
+- person tag, added as 'contractor'
+- target utilisation (check with the project lead they will be working with when adding this in)
+
+We ignore the input fields for email address, phone number and employee codes, as this information isn’t something we record in 10kft for Contractors.
+
+#### Permission levels
+
+Project leads will have administrator permission levels. Team members who are billable members of the team, but don’t lead on projects will have 'team member' permissions. There are six different types of permission levels on 10kft. We use the following four:
+
+**Administrator:** People with Administrator level access can change company account settings, alter schedules, adjust bill rates, add/remove people and projects, reset passwords, and confirm others’ time.
+ 
+**Scheduler:** The Scheduler permission level is meant for people who make day-to-day changes to the Schedule, but should not have access to the project’s settings. They have all the permissions of the Project Manager, except the ability to create/edit projects, add/invite people, edit account settings, edit people profiles, and confirm others’ time.
+ 
+**Team Member:** The Team Member permission level allows the person to see information on all projects and people within the organization, including budgets and other financial details. However, Team Members cannot edit assignments.
+ 
+**Contractor:** These people can only view their personal page for time tracking and projects they’re assigned to. Contractors can account for time only on projects that they’ve been assigned to by an Administrator or Project Manager.
+
+We use our judgement to assign a permission level for a new user. If you’re not sure, ask in the #scheduling slack channel.
+
+We don't actively assign team members the following permission settings:
+
+**Project Manager:** People at the Project Manager level have the ability to adjust schedules and allocate people to different projects.
+
+**Restricted Team Member:** People with the Restricted Team Member permission level have the same access as Team Members, with the exception that they cannot see any financial details and Analytics.
+
+#### Availability
+
+By default, those working on billed client work, within the delivery and technical operations functions, should all be set to a part time working pattern. We work a 4 day client week, meaning although team members work on Fridays, they are not typically assigned to client work. 
+
+Team member availability is set at 7 hours per working day, from Monday to Thursday.
+
+On Fridays, we spend time on internal activities, which isn’t tracked in 10kft. For all team members, availability on a Friday should always be set to 0 hours a day.
+
+On occasion, we work 9 day sprints. We don’t change the set up of a team members availability for this, we just schedule the team member onto a project on a Friday, which they then confirm.
+
+**Working patterns at dxw**
+
+Most team members at dxw work a 5 day / 35 hour week.
+
+dxw provides [flexible working](http://playbook.dxw.com/#/?id=flexible-working). This means that not everyone works the same hours week on week. Team members working patterns need to be applied during their account set up, so that it accurately represents availability to work on billed projects.
+
+More information can be found about an individual team members working patterns, by speaking with their line manager. This can be via the #hr-non-confidential slack channel or 1:1.
+
+Only **admins** can change team member’s working patterns. If it’s not possible to change a team members’ working pattern, raise this in the #scheduling slack channel.
+
+A weekly working pattern that differs from the default should be set by the Commercial Operations team. Where a team member has a working pattern that operates on a fornightly cycle, line managers are required to ensure this is updated on a regular basis. This is due to how 10kft is set up.
+
+**Setting a team member’s availability**
+
+- add the users ‘First day of work’
+- under the button that asks to ‘add part-time availability’, there will be an option to enter in a team member’s availability
+
+Typically, this will need to be set by adding 7 into the boxes across Monday - Thursday and putting a zero in the box for Friday. This reflects the seven hour day a team member works on a project. 
+
+***Although dxw bill clients in days, we track time in 10kft on an hourly basis, due to the way 10kft is set up.***
+
+It’s important to set this correctly, as it displays a team member's availability to take on new work in the schedule view of 10kft.
+
+If it's unclear how to assign availability, speak to the Commercial Operations team who will be able to help.
+
+Contractor accounts will need the availability set based on the agreement in a Contractor's work outline. If this hasn’t been added, speak to the Commercial Operations team.
+
+#### Utilisation
+
+For reporting, it’s important to add a utilisation rate for each team member. When adding a new team member, speak to our CTO, who will be able to advise the correct utilisation rate for the individual.
+
+#### Bill rates
+
+Under Bill rates, make sure the button for ‘Use the default bill rate based on discipline and role’ is ticked.
+
+Next, select the discipline the team member belongs to. For example, development, design, research, etc..
+
+#### People tags
+
+Finally, add tags for team members. These should describe the team member in a way that complements their role. Team members should always have two tags assigned to them. These are either:
+
+- ‘Permanent’ or ‘Contractor’
+- ‘Delivery’, ‘Strategy’ or ‘Technical Operations’
+
+If the team member is an employee that doesn’t sit within the three business functions (delivery, strategy and technical operations), assign the tags ‘unbillable’ and ‘permanent’.
+
+***After the above sections are updated, click ‘Add’, which completes the account set up.***
+
+### Adding a new project
+
+Team members with “Scheduler” or “Admin” permissions can add projects to 10kft.
+
+#### What qualifies as a project?
+
+All billable work under our delivery, strategy and technical operations functions count as projects we need to be tracking. 
+
+If a team is working on an internal project we treat similarly to billed work, this should be added to reflect our investment.
+
+#### When to add a new project
+
+When working on a new sales opportunity,the sales lead involved in the bid will need to add this 10kft.
+
+When existing work is extended, the project lead will add the new project to 10kft. An example of this could be an Alpha, that’s followed on from Discovery.
+
+If the work is tentative, this should still be added and reflected in 10kft. This is so it can be discussed in scheduling.
+
+#### How to add a new project
+
+Once signed in, go to the **projects** tab in the navigation. On the right hand side click the ‘New Project’ button.
+
+![Image of projects tab in navigation on 10kft](http://playbook.dxw.com/guides/Image%20of%20projects%20tab%20in%20navigation%20on%2010kft.png)
+
+Then complete the following project information. If a project is tentative, we try and fill in as much detail as possible. If any section is unknown, this can be left blank, until it has been confirmed. 
+
+**When a project is won and a project lead is assigned, they are responsible for ensuring the project set up has been completed accurately.**
+
+Until a project is won, the ‘Project Type’ is set as ‘tentative’.
+
+![Image of adding project information in 10kft](http://playbook.dxw.com/guides/Image%20of%20adding%20project%20information%20in%2010kft.png)
+
+When adding a project, all of the settings will be set to the default. Unless this information varies, we leave as the default setting, aside from 'project tags'.
+
+![Image of project tags example in 10kft](http://playbook.dxw.com/guides/Image%20of%20project%20tags%20example%20in%2010kft.png)
+
+We track projects against six project tags: cyber, delivery, dxwNorth, Hybrid, Ops & Strategy. Tags are used to filter projects and pull reports. Add at least one, representing the function the project sits within (delivery, strategy or technical operations). 
+
+### Things to do once a project has been confirmed
+
+#### Confirm the working pattern of your team
+
+When setting up a project it’s important to confirm the working patterns of the team members assigned to the project. Whilst most team members work a 5 day week, some of our colleagues have differing working patterns. This could mean that their day rates might be different or they aren’t available to work some of the days when other team members can. 
+
+Working patterns can be confirmed by speaking to a team members' line manager. This might change the way we bill for this person’s time. Speak to a Director who will be able to confirm this for you.
+
+### Who adds projects?
+
+#### Scheduling purposes
+
+This is likely to be done by a member of the scheduling or sales team and will be done at the tentative stage of the work. When we are shortlisted for a bid, tentative placeholders will be put against the proposed team so availability of team members can be discussed in weekly scheduling meetings.
+
+#### Delivery purposes
+
+This is likely to be done by a sales or project lead and will be completed at confirmation of winning work. The tentative placeholders will then be changed to ‘scheduled’ and assigned to available team members who will join the project. Those team members will then receive a confirmation email within 24 hours informing them on their project placement.
+
+When somebody is assigned from a tentative placeholder to a newly confirmed project, the project lead must drop a message or have a chat with that team member to let them know. It makes it more human.
+
+### How is the support rota reflected?
+
+Developers at dxw take it in turns on the support rota. This needs to be reflected in 10kft, as it affects the availability of individuals to perform client work. dxw's Technical Architect is responsible for both the scheduling of the support rota and updating this in 10kft.
+
+Support weeks run in 1 week cycles and are marked in 10kft as internal project work. Once the rota is confirmed, support weeks will be added into 10kft for visibility and to show developers as unavailable.
+
+On a similar note, some developers in the team volunteer to take on out of hours support. This runs in 1 week cycles and is marked as an internal project. Utilisation for out of hours support is set at 0%, as this is performed outside of the typical working day. This is also added into 10kft, for visibility, but isn’t actively tracked. It’s useful to recognise when developers on project work, are also on out of hours support.


### PR DESCRIPTION
Following the creation of a 10kft handbook, we're publishing it to the guides section of the playbook. 

This is the first part of the handbook, mainly to ensure I've understood the markdown correctly, so I can continue to work through adding the rest of the document.

Link to the handbook here: https://docs.google.com/document/d/1wKP1Y62FLuQoc9eJ4NXivere92JGq7tBHQ8WvnTcahU/edit#