### PR TITLE
Improve vale linting on CI

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,5 +1,5 @@
 StylesPath = styles
-MinAlertLevel = suggestion # suggestion, warning or error
+MinAlertLevel = warning # suggestion, warning or error
 # Only Markdown and .txt files; change to whatever you're using.
 [*.{md}]
 # List of styles to load.

--- a/README.md
+++ b/README.md
@@ -111,3 +111,9 @@ To run the prose linter:
 ```
 npm run vale
 ```
+
+This will only show errors and warnings by default. If you want extra suggestions for better writing, run:
+
+```
+npm run vale-suggestions
+```

--- a/README.md
+++ b/README.md
@@ -109,5 +109,5 @@ npm run lint
 To run the prose linter:
 
 ```
-vale [fileYouWantToLint].md
+npm run vale
 ```

--- a/guides/setting-up-a-new-project.md
+++ b/guides/setting-up-a-new-project.md
@@ -1,7 +1,7 @@
 # Setting up a new project
 
-At dxw we frequently start new projects and work with clients we haven’t worked with before. 
-Delivery leads at dxw are responsible for setting up projects and ensuring all the right things are in place for when the team starts work. 
+At dxw we frequently start new projects and work with clients we haven’t worked with before.
+Delivery leads at dxw are responsible for setting up projects and ensuring all the right things are in place for when the team starts work.
 
 We often find that time is limited and transitioning between projects can be a challenge, for delivery leads and the wider team.
 
@@ -9,11 +9,11 @@ This guide provides advice and tips, as well as a checklist for delivery leads a
 
 ## Before a project starts
 
-In most cases, there’s not a very long lead time between winning a piece of work and starting it. We sometimes have a number of days, rather than weeks, for the team to get everything in place. This includes things like contracts, scheduling a team to do the work and making a plan for the first few days. 
+In most cases, there’s not a very long lead time between winning a piece of work and starting it. We sometimes have a number of days, rather than weeks, for the team to get everything in place. This includes things like contracts, scheduling a team to do the work and making a plan for the first few days.
 
 We’re lucky if the same delivery lead has been involved in the sales work that led to the project being won, because there’s always other work in flight. It’s important that knowledge is shared and the necessary introductions made so we can get the work off to a good start.
 
-It is however worth remembering that most of our sales proposals are produced with limited information about the project, and it’s only once we start that we get a better idea of what the work is and what skills we’ll need to do it. 
+It is however worth remembering that most of our sales proposals are produced with limited information about the project, and it’s only once we start that we get a better idea of what the work is and what skills we’ll need to do it.
 
 There are several things that delivery leads should do first, regardless of the shape of the project:
 
@@ -67,7 +67,7 @@ While the project is being set up, and before it starts, a kick off should happe
 - We realise our priorities so we have an initial plan
 - We discuss ways of working
 
-You should have everyone working on the project in this meeting (even if they’re part-time). 
+You should have everyone working on the project in this meeting (even if they’re part-time).
 
 ### Introductions
 
@@ -80,7 +80,7 @@ It shouldn’t just be about people’s names, but roles and what each person wi
 - Prep the client about what the day will look like and set expectations. For example who they should bring and what the agenda should be.
 
 ### Get to a shared understanding of what the work and priorities are
-There are a number of outcomes you should look to get out of a kick-off. This is important especially if we are working with that client for the first time and there are areas that are not very clear to us, or to them. You can structure a kick-off in the way that works best for you, but some frameworks that will help you get the outcomes you need are below:
+There are a number of outcomes you should aim to get out of a kick-off. This is important especially if we are working with that client for the first time and there are areas that are not very clear to us, or to them. You can structure a kick-off in the way that works best for you, but some frameworks that will help you get the outcomes you need are below:
 - [Running a discovery kick-off workshop](http://playbook.dxw.com/#/guides/running-a-discovery-kick-off-workshop)
 - [Running a roadmapping workshop](http://playbook.dxw.com/#/guides/running-a-roadmapping-workshop)
 
@@ -103,14 +103,14 @@ Give an overview of how dxw works. Don’t assume that everyone in the client te
 - dxw days, that is 9 days in a 10 day sprint
 - invoicing and finances, we invoice the first day after the end of each sprint, based on the number of days each specialist in the team worked. We might also add travel costs, or research incentives, and other admin costs as per the commercial agreement we have with the client
 
-It is also important to mention that we work with roadmaps, which might change over time as we know more about the project. This is fundamental in an agile project, so that we can react to change as quickly as possible. Therefore, we do have plans, but they are not set in stone.  
+It is also important to mention that we work with roadmaps, which might change over time as we know more about the project. This is fundamental in an agile project, so that we can react to change as quickly as possible. Therefore, we do have plans, but they are not set in stone.
 
 Tell the client that if, at any point, they have an issue with the way we are working, or with any team member, the first point of contact for them is the dxw Delivery Lead. If the DL is the problem area or if they are a contractor, the Director of Delivery is then the next point of contact.
 
 
 ### Discuss how the team want to work
 
-Clients will have their own way of working on projects and if they’ve used agile approaches before, it may be a different flavour of agile to what the dxw team are used to. Ask the client team to talk about how they’re used to working on projects and agree some principles for how the single team will work together. For example, do they typically follow the GDS Service Manual? 
+Clients will have their own way of working on projects and if they’ve used agile approaches before, it may be a different flavour of agile to what the dxw team are used to. Ask the client team to talk about how they’re used to working on projects and agree some principles for how the single team will work together. For example, do they typically follow the GDS Service Manual?
 
 Explain how most dxw teams work, and communicate to the client that we’ve done this successfully with different clients over the years. However, be accommodating and suggest we “test and iterate” approaches. The retros are a perfect avenue to explore these.
 
@@ -119,7 +119,7 @@ There’s always something to discuss here.  For example, how will week notes be
 
 ### Talk about co-location
 
-If you’re going to be co-located with the client, ask to visit the office space and have a look around. Make sure that the team have access to the site (do they need passes) and that you have space to work. This includes space to run sprint meetings and show and tells. Work with the Commercial Operations team to order any equipment or things the team will need. It’s also worth agreeing which days will be spent co-lo and which at dxw in this meeting. Take the teams working patterns into account. 
+If you’re going to be co-located with the client, ask to visit the office space and have a look around. Make sure that the team have access to the site (do they need passes) and that you have space to work. This includes space to run sprint meetings and show and tells. Work with the Commercial Operations team to order any equipment or things the team will need. It’s also worth agreeing which days will be spent co-lo and which at dxw in this meeting. Take the teams working patterns into account.
 
 When the team are going to be in different locations, think about technology and how to make sure each team member is able to join meetings and work with others. It might be useful to buy some extra microphones, good headphones or additional screens for the team. Chat to Olivia if you have any questions.
 

--- a/guides/style-guide.md
+++ b/guides/style-guide.md
@@ -91,21 +91,21 @@ or 'g-cloud' or 'G Cloud' or 'GCloud'.
 
 <!-- vale Dxw.GovPress = YES -->
 
-<!-- vale Dxw.Multisite = NO -->
+<!-- vale Dxw.multisite = NO -->
 
 **multisite**: if referring to the feature directly, "Multisite" should be
 capitalised. If referring to an multisite WordPress setup, "multisite". Never
 "multi site" or "multi-site".
 
-<!-- vale Dxw.Multisite = YES -->
+<!-- vale Dxw.multisite = YES -->
 
 **open source**: always lower case.
 
-<!-- vale Dxw.Plugin = NO -->
+<!-- vale Dxw.plugin = NO -->
 
 **plugin**: not 'plug in' or 'plug-in'.
 
-<!-- vale Dxw.Plugin = YES -->
+<!-- vale Dxw.plugin = YES -->
 
 **Rails**: for the Ruby framework, always upcase. Lower case is fine for the
 things trains run on.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "dxw Playbook",
   "scripts": {
     "start": "docsify serve .",
-    "lint": "remark ."
+    "lint": "remark .",
+    "vale": "~/go/bin/vale */*.md *.md"
   },
   "dependencies": {
     "docsify": "^4.5.5",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "docsify serve .",
     "lint": "remark .",
-    "vale": "~/go/bin/vale */*.md *.md"
+    "vale": "~/go/bin/vale */*.md *.md",
+    "vale-suggestions": "~/go/bin/vale --minAlertLevel suggestion */*.md *.md "
   },
   "dependencies": {
     "docsify": "^4.5.5",


### PR DESCRIPTION
Vale is lovely, but leaves a lot of noise on PRs, because it includes sometimes-inappropriate suggestions.

So that we can trust it again and not ignore it, I've changed it to only show warnings and errors by default. There is a new npm script to run the full thing with suggestions as well. This should make our PRs quieter, and mean we can enforce the style guide properly as a required test on PRs.