### PR TITLE
Move the Our professions content

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -435,514 +435,6 @@ the client and the delivery team to respond quickly to challenges as they arise.
 If priorities change during a sprint, the delivery lead works with the client
 to understand and plan for the impact of the change.
 
-## Professions
-
-### Leadership
-
-At dxw, we believe that great teams need great leaders.
-
-#### Leadership principles
-
-Whether or not they are in a formal management role, leaders at dxw are guided by these principles.
-
-1. **Set an example**
-
-   Leaders at dxw demonstrate our values in everything we do. We set high standards of behaviour and inspire both colleagues and clients to do the same.
-
-   We demonstrate fairness, integrity, and resilience, and build trust with our actions.
-
-1. **Look after people**
-
-   Leaders at dxw promote the wellbeing of individuals, teams and communities. We encourage a supportive culture and inclusive working arrangements. We prioritise 1:1 time with people to listen and understand their particular needs.
-
-   We support and defend colleagues in difficult situations. We identify and deal with poor performance and bad behaviour.
-
-1. **Take ownership**
-
-   Leaders at dxw welcome responsibility and accountability. We’re proactive, pick up things that need doing without being asked and push to finish the job in hand.
-
-   We’re the first to admit mistakes, apologise when wrong and learn for next time.
-
-1. **Deliver for clients**
-
-   Leaders at dxw understand how to deliver value for each client and create the conditions for dxw to do brilliant work. We are not afraid to challenge clients or ask difficult questions.
-
-   We think commercially and push dxw to grow and strengthen as a business.
-
-1. **Provide clarity**
-
-   Leaders at dxw communicate clearly and concisely through the right channel. We question any decisions, goals or explanations that are vague or ambiguous and work to clarify them.
-
-   We’re open, honest and straightforward in what we say and write. And we provide specific, understandable and useful feedback.
-
-1. **Make good decisions**
-
-   Leaders at dxw use evidence and judgement to make good decisions. We know that timely decisions are important, so we don’t procrastinate or fudge. We commit to collective decisions, particularly when we originally disagreed.
-
-   We consult broadly, seek out contrary opinions, and listen to quieter voices. We make sure we can explain our decisions, with context, rationale and evidence.
-
-1. **Point the way**
-
-   Leaders at dxw share an inspiring vision for the future of dxw, and each individual’s part in it.
-
-   On client and dxw projects, we make sure that colleagues understand the outcomes we want to achieve and the value that they will create.
-
-1. **Build the future**
-
-   Leaders at dxw hire great people. We actively look for the widest range of candidates to strengthen our diversity.
-
-   We encourage our colleagues to learn, develop new skills, and pursue their career aspirations, whether at dxw or elsewhere. And we give people opportunity and responsibility at the right pace for them.
-
-   We continually improve dxw capability, and the effectiveness and efficiency of our delivery. We try out new approaches and technologies and give others the time and space to do the same.
-
-### Strategy
-
-We create the conditions and in-house capability our clients need to deliver and keep improving great services.
-
-#### Strategy team principles
-
-The strategy team apply these principles to our work.
-
-1. **Bring people together to make the right decisions**
-
-   We facilitate activities to help organisations make good decisions, prioritise and create the momemtum for change.
-
-1. **Focus on impact and sustainable change**
-
-   We’re here to create significant long-term change. We won’t get involved if we don’t believe that’s possible.
-
-1. **Question the brief**
-
-   Before starting delivery we interrogate the brief to make sure it is clear, realistic and provides the foundation for delivery teams to start work.
-
-1. **Meet organisational goals as well as user needs**
-
-   We help organisations clarify their goals and set up the right measures to track performance and progress. So they can deliver better services for the people who need them.
-
-1. **Use methods that work**
-
-   We use established methods where we can, or develop new ones where we need to.
-
-1. **Create the conditions to deliver**
-
-   We set up teams to deliver and keep improving once we’re gone.
-
-### Delivery management
-
-#### Delivery management principles
-
-Delivery leads at dxw are guided by these principles.
-
-**Maintain diplomacy**
-
-We encourage calmness and patience, we ensure all voices are heard in a fair way and we’re always proactive to get stuff done.
-
-**Demonstrate leadership**
-
-We have the autonomy to lead and to say no, we’re responsible for empowering delivery teams to do great things and we coach others to get the best from them.
-
-**Show strength & resilience**
-
-We protect the team so they can focus, we remove blockers and distraction and we provide context and see the bigger picture.
-
-**Enable, empower & encourage**
-
-We create space for the team to deliver and individuals to thrive, we build up trust with the team, our clients and our stakeholders to support decision making and progress and we’re always supportive and demonstrate positivity, with a focus on delivery.
-
-**Prioritise learning & improving**
-
-We actively learn from what we do and take responsibility to ensure that learning feeds back into what we do next and we stand by our ability to facilitate communication and constructive conversation.
-
-### Product management
-
-#### Product management principles
-
-Product managers at dxw follow these principles.
-
-1. **Set the destination, don’t chart the course**
-
-   Product managers help empower multidisciplinary teams by refining and articulating the problem the team is trying to solve, and the outcomes they‘re trying to produce.
-
-   Communicating the vision and goals for a project through a clear and well-maintained roadmap is a core part of product management.
-
-1. **Define and defend scope**
-
-   Getting agreement from everyone involved is crucial to successful delivery.
-
-   Product managers should set the direction at the start of a project, and continue to articulate, communicate and defend the scope throughout, so that the team can focus on delivering.
-
-1. **Convert insight into action**
-
-   User research helps inform our objectives, goals, and priorities by telling us more about the problems users are having with the current state, or the needs they have for something different.
-
-   Product managers need to be able to balance user research insights with constraints like time, capacity, and strategic objectives to prioritise the next most important thing.
-
-   Product managers help the team to work together, across disciplines, to identify potential solutions before choosing a way forward.
-
-1. **Have a service mindset**
-
-   Product managers recognise that a digital product is often not the whole solution to a problem, and that the people operating a new service day to day are users too.
-
-   We think about the processes and systems around a product, including how those might change.
-
-1. **Communicate clearly how short term outcomes contribute to long term goals**
-
-   Product managers need to own and articulate a vision that is consistent and meaningful to everyone with an interest in the project, from the delivery team all the way through to the most senior stakeholders, and users.
-
-1. **Be present, collaborative, and consistent**
-
-   Being available to the team to discuss the unexpected and share in the decision making is central to building empowered and protected teams.
-
-   Product managers should regularly and actively communicate, review and defend our decisions - especially the unplanned or unexpected ones.
-
-1. **Maintain a focus on outcomes**
-
-   In the midst of delivery, key dates can loom large, and teams can be diverted onto things which seem urgent but aren‘t important.
-
-   Product managers must help teams and stakeholders remain focused on outcomes over outputs, facilitating discussion and making space for reflection.
-
-1. **Lead without authority**
-
-   Product managers shouldn‘t be bottlenecks. Product managers and delivery leads work together to build skilled multidisciplinary teams and create the space in which those disciplines can do their best work.
-
-   Product managers are open to new tools, techniques and approaches, working with teams to find what works.
-
-1. **Take blame, give credit away**
-
-   Good product managers leave their ego at the door, taking negative feedback on board whilst ensuring the team are rightly recognised for their work and achievements.
-
-   Being kind is more important than being right - it‘s a good rule of thumb to enter every conversation without assuming that you already know most, or best.
-
-1. **Strong opinions, softly held**
-
-   Product managers make the best decisions based on the available information with confidence, staying open to the possibility that things could change when more information is available in the future.
-
-   Product managers communicate the trade-offs they’re making and the rationale for their decisions so that teams can understand how a decision was reached, even when they don’t agree.
-
-1. **Set clear priorities**
-
-   Product managers work with the team, stakeholders and users to define priorities, and ensure these are clear.
-
-1. **Measure outcomes**
-
-   Product managers facilitate and work with service designers and business analysts to work out key metrics and goals for the product and work with the team to define roadmaps to achieve these goals.
-
-Hat tip to [Ross Ferguson](https://medium.com/@rossferg/the-principles-that-make-me-a-better-product-manager-9e50814d184f) for inspiring several of these principles.
-
-### User research
-
-At dxw, we believe in making decisions based on evidenced user needs. As user researchers, we help multidisciplinary teams learn about users and recognise the value of user research. There is no single right way of doing this, but as a team, we need to stay unified in the way we approach, do, and talk about research.
-
-#### User research principles
-
-Our principles are not rules. They guide our work, keep us improving as a team, and working with, not for our clients.
-
-1. **Help teams understand people**
-
-   Researchers at dxw help our teams build a deep understanding of the people who use our services. We know that‘s the best way to create public services that work well for the people who need them.
-
-   We are facilitators, not gatekeepers. We actively involve our colleagues and clients in research. And openly share what we do, how we do it and why it‘s important.
-
-1. **Find the truth. Tell the truth**
-
-   Researchers at dxw create strong evidence and reliable answers so our teams can act with confidence. We are bold and focus on what‘s most important.
-
-   We know we can learn things that are unexpected and challenging. So we communicate clearly and sensitively to help everyone make the best decision.
-
-   (Credit to the great [Dana Chisnell](https://twitter.com/danachis/status/802930860030918656) and the [United States Digital Service](https://www.usds.gov/mission) for this one)
-
-1. **Take ethics seriously**
-
-   Researchers at dxw know that the safety and trust of participants is our responsibility. We think about the ethics of our research at every step. From how we recruit participants and get their informed consent, through how we store and use the data we collect, to how we share our findings.
-
-1. **Be methodical, but not rigid**
-
-   Researchers at dxw know that the quality of our findings depends on the quality of our methods. We use tried and tested methods, and take time to reflect and continually improve our practice.
-
-   But we also understand that context is important. So we use the best approach for the question at hand and adapt our ways of working to fit the client and the project.
-
-1. **Learn, share and adapt**
-
-   Researchers at dxw work in an agile way. We do research and analysis in small batches so we can continuously share and adapt to what we learn.
-
-1. **Make research inclusive**
-
-   Researchers at dxw know how important it is that public services work for all the people who need to use them. We help teams understand the needs of all their users, and do research activities that everyone can participate in.
-
-1. **Build on existing evidence**
-
-   Researchers at dxw help clients build on the knowledge and data they already have. We combine existing knowledge, poorly understood data and new research into a coherent picture.
-
-1. **Accept and admit constraints**
-
-   Researchers at dxw do the best research we can within the constraints we have. We acknowledge and share the limits of our research and our findings. And we advocate for more research when it‘s needed to achieve the project outcomes.
-
-#### User research guidance
-
-The Playbook includes detailed guidance on [how we do user research at dxw](https://playbook.dxw.com/#/guides/how-we-do-user-research).
-
-The guide starts with the user research workflow, which describes the things that user researchers usually do on projects, and then provides further guidance and links to resources for specific topics.
-
-### Design
-
-#### Design team principles
-
-Designers at dxw follow these principles:
-
-1. **Democratise the design process**
-
-   Take into account, and value highly, the input of others in the design process. While we are ultimately responsible for design in a delivery team, we don’t work in isolation.
-
-1. **Value clarity in everything we do**
-
-   Use plain language in interfaces, writing and conversation.
-
-1. **Overlap with other disciplines**
-
-   Work closely with people that have different skills to you, in the knowledge that different perspectives make our decisions stronger and elevate our work.
-
-1. **Communicate constantly**
-
-   Never go missing. Our teammates always understand what we’re doing and why, because we’re all aiming for the same outcome.
-
-1. **Know we are not the user**
-
-   Do not assume to know how users of our services think or act. We acknowledge that things such as genetics, upbringing, religious and geographical culture, and past experiences make us all different. We work closely with our user researchers to gain understanding and insight about the people that use the things we design. _“One accurate measurement is worth more than a thousand expert opinions.”_ ~ Grace Hopper
-
-1. **Be educators**
-
-   Know that being open about our work, and helping others to understand our decisions and why we make them, benefits everybody.
-
-1. **Be kind**
-
-   Be tolerant, understanding, empathetic and compassionate. Look for opportunities to help and care for others. Putting people at the centre of everything will help you be a better designer.
-
-1. **Embrace questions**
-
-   Understand that when people ask questions and give feedback it is to make something better. If we can not articulate our decisions then we may not have made the best choice.
-
-1. **Ask questions**
-
-   Always ask questions and seek the truth;  when we understand the problem we can solve it. When things seem muddy take a step back and try and find the original intent or gaps in understanding. _“If I had an hour to solve a problem I’d spend 55 minutes thinking about the problem and five minutes thinking about solutions.”_ ~ Albert Einstein
-
-1. **Always assume the best intent**
-
-   We are passionate about what we do, but we are a team. When you have difficult conversations or feedback we should always assume that it is coming from a good place.
-
-1. **Tell stories**
-
-   When we talk about our work and why we do what we do, do not just state the facts. Inject some humanity into it; turn it into a story with a beginning, a middle,  and an end.
-
-### Development
-
-#### Development principles
-
-1. **Solve real user needs**
-
-   Good code starts with understanding, and is rooted in the real world. We work
-   in multi-disciplinary teams, but you’re not just there to churn out code. Get
-   involved in the research and design. Understand the needs of the users and
-   the constraints of the organisations we’re working with.
-
-   Ultimately, it’s about the user and their needs, not about technology.
-   Sometimes software is not the answer.
-
-1. **Own your code, but collaborate**
-
-   Having the opportunity to see a piece of work through to completion is a
-   great way to get stuff done, and for developers to grow. Take ownership of
-   your work to get it all the way through our development process to being used
-   by users.
-
-   Ownership gets stuff done, but collaboration makes it better. So involve the
-   rest of your team in your work: agree approaches, highlight tradeoffs and
-   seek out reviews. Get all your code reviewed by another developer to help us
-   ship better quality code, get the opportunity to learn new skills, and
-   increase the shared knowledge of our products. Request feedback, ask
-   questions and discuss code, but ultimately the author is responsible for
-   making changes.
-
-1. **Security is a user need**
-
-   Sometimes the simplest or easiest solution is not the most secure, and we
-   fight for our user’s safety and security, even when a client doesn’t agree.
-
-1. **Use simple, conventional technology**
-
-   By default, use straightforward technology and conventional approaches. The
-   services we built have to be maintained and iterated on by small, and
-   sometimes less experienced, teams. Keeping things simple ensures that is as
-   painless as possible.
-
-   Vary from convention only on the domain specific stuff, where it adds the
-   most value.
-
-1. **Build for quality and consistency**
-
-   Think about those who come after us. We build high quality systems with the
-   lowest possible maintenance burden. We write tests, use linters, follow
-   standards and conventions, and document our decisions. The things we build
-   should be set to thrive after we leave.
-
-1. **Improve with each iteration**
-
-   Always leave the codebase in a slightly better place than when you found it.
-   Look for opportunities to refactor difficult code, to improve documentation,
-   or to extract shared functionality.
-
-1. **Communicate clearly and frequently**
-
-   Help our future selves and others by recording the reasons for our actions.
-   Explain the changes you’re making to code through your commit messages and
-   pull requests. Explain the decisions you’re making about technology through
-   architecture decision records. Explain the tradeoffs you’re making in
-   planning and show and tells.
-
-   Use straightforward language, even when you’re dealing with complex technical
-   issues. Prefer to write it down over speaking it out, to ensure a lasting
-   record.
-
-1. **Be humble, supportive and open minded**
-
-   Assume other people on your team know things you don’t. Feel comfortable
-   saying “I don’t know”.
-
-   Assume you know things other people on your team don’t, but be prepared to be
-   wrong. Ask questions rather than giving instructions. Share your opinions and
-   experience openly with your team.
-
-   Question the obvious and test our assumptions. Listen to the client and the
-   users and their experiences.
-
-   Be non-judgemental – assume everyone did the best they could at the time,
-   with what they knew and the resources available.
-
-1. **Always learning. Always teaching**
-
-   Technology never stops, and the amount to know even for our limited stack is
-   huge, so we must learn and share. We teach each other through peer mentoring,
-   pairing and reviews.
-
-   Share what you learn on a project with the whole team so we can reuse
-   knowledge across projects. Encourage others in their learning.
-
-1. **Do the smallest amount of good work**
-
-   We aspire to regularly ship good code, and deliver it to the users as often
-   as possible. Delivering impact fast by shipping something real has a big
-   impact on the morale of the team and happiness of our clients and users.
-
-   Where you can, do less and deliver it sooner. Break down work into smaller
-   pieces. Descope anything that isn’t critical for a first version. Do a
-   minimum slice that works for some of your users. Anything to reduce the time
-   between get started on something and delivering it to users.
-
-   Work at a pace that suits the project. Hacky is sometimes fine. If you’re
-   working on prototypes then do only what you need to answer your questions.
-   Sometimes, if you’re working on critical production systems, you’ll have to
-   go slower. When that’s the case, it’s even more important to break down the
-   work into the smallest reasonable chunks, to demonstrate progress, to make
-   reviewing the changes as easy as possible, and to prove your assumptions.
-
-1. **Work in the open**
-
-   Be open by default. Code should be public unless there’s a good reason
-   otherwise. Changes to open source libraries should be contributed back to the
-   project. Dashboards should be public wherever reasonable.
-
-   The way we’re working should also be open to our clients. Work being done
-   should be represented in Trello boards that everyone can see. Communication
-   should be done in public Slack channels rather than direct messages. Openly
-   communicating about our work allows clients to see how we’re doing, and what
-   needs their attention, and gives everyone in the team context for the work
-   being done and decisions being made.
-
-### Commercial Operations
-
-We are the team that enables and encourages dxw to achieve its mission(s) and uphold its values.
-
-#### Commercial Operations Team Principles
-
-##### Things we do:
-
-1. We deliver the dxw business plan. In particular, we recruit the best people to meet our mission, manage our finances to allow sustainable growth, and track performance of objectives to measure ourselves.
-
-1. We are the front door for staff and clients. We help, support and enable dxw to meet its mission and uphold its values. We do this by being empathetic and put people over process.
-
-1. As commercial experts we take the burden away from our delivery teams, and make sure our people, as well as our suppliers get paid, whilst also ensuring our clients pay us on time.
-
-1. The unit of delivery is always the team, so we ensure staff wellbeing by providing a safe and inclusive environment. We also support our people to thrive in all stages of their careers, ensuring they have chance to continually learn, as well as excellent facilities and the right tools to enable them to succeed in their careers.
-
-1. We ensure dxw is compliant with all the relevant company and employment regulations, ensuring we have ISO 27001 accreditation, abide by GDPR guidelines and insurance.
-
-1. Commercial and business operations can be thankless, but to manage expectations we remain resilient and take responsibility for our work by effectively communicating about what we do and why we do it.
-
-##### Behaviours
-
-1. Empathetic to our users / staff / suppliers / clients.
-
-1. Support each other to support the team.
-
-1. Commercial accuracy and responsibility.
-
-1. We are balanced, organised and resilient.
-
-1. People over process, to maintain our unique, small-company, culture.
-
-1. We are proud of what we do and are confident enough to talk about it.
-
-1. We manage expectations by taking responsibility for our work and communicating what we do and why.
-
-1. We _are_ the company values.
-
-### Sales and marketing
-
-#### Sales and marketing team principles
-
-The sales and marketing teams at dxw follow these principles:
-
-1. **Start from solid foundations**
-
-   We work with potential and current clients to understand their needs and how we can deliver value - seeking out   opportunities for mutual growth.
-
-   We support our clients to make the right buying decisions, ensuring we focus on positive outcomes for users and making the most of the resources available.
-
-   We work closely with our delivery team so we can be open with clients about who will be available to do the work and realistic delivery timescales.
-
-1. **Build positive relationships**
-
-   We work in partnership with our clients, and are open and transparent at all times.
-
-   We remain responsible and accountable to both our delivery teams and clients, ensuring that we represent them in the right way and can deliver on our commitments.
-
-   We give our clients the opportunity and platform to talk openly about their experience of working with us.  We listen to what they’re telling us - about what’s going well and what we need to do differently - and constantly work to improve things.
-
-1. **Find the right work**
-
-   We welcome new opportunities, and actively seek input from the dxw team to help us decide whether an opportunity is ‘dxw shaped’.
-
-   We consider the ethical implications of the work - does it help to create better digital public services that make people’s lives better?
-
-   We will only take on work that’s a good fit for the team - that won’t put us under undue strain, where our team will be safe and we can have a positive relationship with our client.
-
-1. **Show the work and the team**
-
-   We’re an active part of the digital and tech community that’s working to build better public services.
-
-   We talk openly about what we’re doing and why, what we’re learning along the way and share our ideas and expertise. We blog all the time.
-
-1. **Have a clear voice**
-
-   Whenever we communicate - online or face-to-face - we’re always clear, to the point, friendly, and professional. You can rely on us to say it like it is.
-
-   We champion the things that matter to us and our clients. We’re bold and pragmatic and seek to influence change for the better in the way public services are created and delivered.
-
-1. **Communicate with a purpose**
-
-   When we communicate, it’s to explain what we’re doing and the impact of our work so our clients and potential clients understand our areas of expertise and how we can help them.
-
-   We’re open about our values and the way we work in dxw digital. We give our team members a voice because we’re proud of our diverse and inclusive culture.
-
 ## Meetings with your manager
 
 ### One-to-ones
@@ -2304,4 +1796,516 @@ We are aware that digital services have a significant environmental impact. We a
 
 ### Our Behaviours
 
-Whenever possible we opt for rail travel. Due to client needs this isn’t always possible but we’re investigating how offset our carbon footprint in future. We often work remotely which reduces the need for travel. We’re exploring ways to lower our own individual environmental impact. 
+Whenever possible we opt for rail travel. Due to client needs this isn’t always possible but we’re investigating how offset our carbon footprint in future. We often work remotely which reduces the need for travel. We’re exploring ways to lower our own individual environmental impact.
+
+## Our professions
+
+At dxw we come together regularly in different professions to share, to learn, to improve our individual skills and developer our practice as a community.
+
+We also connect out to wider communities of practice who share our values.
+
+### Leadership
+
+At dxw, we believe that great teams need great leaders.
+
+#### Leadership principles
+
+Whether or not they are in a formal management role, leaders at dxw are guided by these principles.
+
+1. **Set an example**
+
+   Leaders at dxw demonstrate our values in everything we do. We set high standards of behaviour and inspire both colleagues and clients to do the same.
+
+   We demonstrate fairness, integrity, and resilience, and build trust with our actions.
+
+1. **Look after people**
+
+   Leaders at dxw promote the wellbeing of individuals, teams and communities. We encourage a supportive culture and inclusive working arrangements. We prioritise 1:1 time with people to listen and understand their particular needs.
+
+   We support and defend colleagues in difficult situations. We identify and deal with poor performance and bad behaviour.
+
+1. **Take ownership**
+
+   Leaders at dxw welcome responsibility and accountability. We’re proactive, pick up things that need doing without being asked and push to finish the job in hand.
+
+   We’re the first to admit mistakes, apologise when wrong and learn for next time.
+
+1. **Deliver for clients**
+
+   Leaders at dxw understand how to deliver value for each client and create the conditions for dxw to do brilliant work. We are not afraid to challenge clients or ask difficult questions.
+
+   We think commercially and push dxw to grow and strengthen as a business.
+
+1. **Provide clarity**
+
+   Leaders at dxw communicate clearly and concisely through the right channel. We question any decisions, goals or explanations that are vague or ambiguous and work to clarify them.
+
+   We’re open, honest and straightforward in what we say and write. And we provide specific, understandable and useful feedback.
+
+1. **Make good decisions**
+
+   Leaders at dxw use evidence and judgement to make good decisions. We know that timely decisions are important, so we don’t procrastinate or fudge. We commit to collective decisions, particularly when we originally disagreed.
+
+   We consult broadly, seek out contrary opinions, and listen to quieter voices. We make sure we can explain our decisions, with context, rationale and evidence.
+
+1. **Point the way**
+
+   Leaders at dxw share an inspiring vision for the future of dxw, and each individual’s part in it.
+
+   On client and dxw projects, we make sure that colleagues understand the outcomes we want to achieve and the value that they will create.
+
+1. **Build the future**
+
+   Leaders at dxw hire great people. We actively look for the widest range of candidates to strengthen our diversity.
+
+   We encourage our colleagues to learn, develop new skills, and pursue their career aspirations, whether at dxw or elsewhere. And we give people opportunity and responsibility at the right pace for them.
+
+   We continually improve dxw capability, and the effectiveness and efficiency of our delivery. We try out new approaches and technologies and give others the time and space to do the same.
+
+### Strategy
+
+We create the conditions and in-house capability our clients need to deliver and keep improving great services.
+
+#### Strategy team principles
+
+The strategy team apply these principles to our work.
+
+1. **Bring people together to make the right decisions**
+
+   We facilitate activities to help organisations make good decisions, prioritise and create the momemtum for change.
+
+1. **Focus on impact and sustainable change**
+
+   We’re here to create significant long-term change. We won’t get involved if we don’t believe that’s possible.
+
+1. **Question the brief**
+
+   Before starting delivery we interrogate the brief to make sure it is clear, realistic and provides the foundation for delivery teams to start work.
+
+1. **Meet organisational goals as well as user needs**
+
+   We help organisations clarify their goals and set up the right measures to track performance and progress. So they can deliver better services for the people who need them.
+
+1. **Use methods that work**
+
+   We use established methods where we can, or develop new ones where we need to.
+
+1. **Create the conditions to deliver**
+
+   We set up teams to deliver and keep improving once we’re gone.
+
+### Delivery management
+
+#### Delivery management principles
+
+Delivery leads at dxw are guided by these principles.
+
+**Maintain diplomacy**
+
+We encourage calmness and patience, we ensure all voices are heard in a fair way and we’re always proactive to get stuff done.
+
+**Demonstrate leadership**
+
+We have the autonomy to lead and to say no, we’re responsible for empowering delivery teams to do great things and we coach others to get the best from them.
+
+**Show strength & resilience**
+
+We protect the team so they can focus, we remove blockers and distraction and we provide context and see the bigger picture.
+
+**Enable, empower & encourage**
+
+We create space for the team to deliver and individuals to thrive, we build up trust with the team, our clients and our stakeholders to support decision making and progress and we’re always supportive and demonstrate positivity, with a focus on delivery.
+
+**Prioritise learning & improving**
+
+We actively learn from what we do and take responsibility to ensure that learning feeds back into what we do next and we stand by our ability to facilitate communication and constructive conversation.
+
+### Product management
+
+#### Product management principles
+
+Product managers at dxw follow these principles.
+
+1. **Set the destination, don’t chart the course**
+
+   Product managers help empower multidisciplinary teams by refining and articulating the problem the team is trying to solve, and the outcomes they‘re trying to produce.
+
+   Communicating the vision and goals for a project through a clear and well-maintained roadmap is a core part of product management.
+
+1. **Define and defend scope**
+
+   Getting agreement from everyone involved is crucial to successful delivery.
+
+   Product managers should set the direction at the start of a project, and continue to articulate, communicate and defend the scope throughout, so that the team can focus on delivering.
+
+1. **Convert insight into action**
+
+   User research helps inform our objectives, goals, and priorities by telling us more about the problems users are having with the current state, or the needs they have for something different.
+
+   Product managers need to be able to balance user research insights with constraints like time, capacity, and strategic objectives to prioritise the next most important thing.
+
+   Product managers help the team to work together, across disciplines, to identify potential solutions before choosing a way forward.
+
+1. **Have a service mindset**
+
+   Product managers recognise that a digital product is often not the whole solution to a problem, and that the people operating a new service day to day are users too.
+
+   We think about the processes and systems around a product, including how those might change.
+
+1. **Communicate clearly how short term outcomes contribute to long term goals**
+
+   Product managers need to own and articulate a vision that is consistent and meaningful to everyone with an interest in the project, from the delivery team all the way through to the most senior stakeholders, and users.
+
+1. **Be present, collaborative, and consistent**
+
+   Being available to the team to discuss the unexpected and share in the decision making is central to building empowered and protected teams.
+
+   Product managers should regularly and actively communicate, review and defend our decisions - especially the unplanned or unexpected ones.
+
+1. **Maintain a focus on outcomes**
+
+   In the midst of delivery, key dates can loom large, and teams can be diverted onto things which seem urgent but aren‘t important.
+
+   Product managers must help teams and stakeholders remain focused on outcomes over outputs, facilitating discussion and making space for reflection.
+
+1. **Lead without authority**
+
+   Product managers shouldn‘t be bottlenecks. Product managers and delivery leads work together to build skilled multidisciplinary teams and create the space in which those disciplines can do their best work.
+
+   Product managers are open to new tools, techniques and approaches, working with teams to find what works.
+
+1. **Take blame, give credit away**
+
+   Good product managers leave their ego at the door, taking negative feedback on board whilst ensuring the team are rightly recognised for their work and achievements.
+
+   Being kind is more important than being right - it‘s a good rule of thumb to enter every conversation without assuming that you already know most, or best.
+
+1. **Strong opinions, softly held**
+
+   Product managers make the best decisions based on the available information with confidence, staying open to the possibility that things could change when more information is available in the future.
+
+   Product managers communicate the trade-offs they’re making and the rationale for their decisions so that teams can understand how a decision was reached, even when they don’t agree.
+
+1. **Set clear priorities**
+
+   Product managers work with the team, stakeholders and users to define priorities, and ensure these are clear.
+
+1. **Measure outcomes**
+
+   Product managers facilitate and work with service designers and business analysts to work out key metrics and goals for the product and work with the team to define roadmaps to achieve these goals.
+
+Hat tip to [Ross Ferguson](https://medium.com/@rossferg/the-principles-that-make-me-a-better-product-manager-9e50814d184f) for inspiring several of these principles.
+
+### User research
+
+At dxw, we believe in making decisions based on evidenced user needs. As user researchers, we help multidisciplinary teams learn about users and recognise the value of user research. There is no single right way of doing this, but as a team, we need to stay unified in the way we approach, do, and talk about research.
+
+#### User research principles
+
+Our principles are not rules. They guide our work, keep us improving as a team, and working with, not for our clients.
+
+1. **Help teams understand people**
+
+   Researchers at dxw help our teams build a deep understanding of the people who use our services. We know that‘s the best way to create public services that work well for the people who need them.
+
+   We are facilitators, not gatekeepers. We actively involve our colleagues and clients in research. And openly share what we do, how we do it and why it‘s important.
+
+1. **Find the truth. Tell the truth**
+
+   Researchers at dxw create strong evidence and reliable answers so our teams can act with confidence. We are bold and focus on what‘s most important.
+
+   We know we can learn things that are unexpected and challenging. So we communicate clearly and sensitively to help everyone make the best decision.
+
+   (Credit to the great [Dana Chisnell](https://twitter.com/danachis/status/802930860030918656) and the [United States Digital Service](https://www.usds.gov/mission) for this one)
+
+1. **Take ethics seriously**
+
+   Researchers at dxw know that the safety and trust of participants is our responsibility. We think about the ethics of our research at every step. From how we recruit participants and get their informed consent, through how we store and use the data we collect, to how we share our findings.
+
+1. **Be methodical, but not rigid**
+
+   Researchers at dxw know that the quality of our findings depends on the quality of our methods. We use tried and tested methods, and take time to reflect and continually improve our practice.
+
+   But we also understand that context is important. So we use the best approach for the question at hand and adapt our ways of working to fit the client and the project.
+
+1. **Learn, share and adapt**
+
+   Researchers at dxw work in an agile way. We do research and analysis in small batches so we can continuously share and adapt to what we learn.
+
+1. **Make research inclusive**
+
+   Researchers at dxw know how important it is that public services work for all the people who need to use them. We help teams understand the needs of all their users, and do research activities that everyone can participate in.
+
+1. **Build on existing evidence**
+
+   Researchers at dxw help clients build on the knowledge and data they already have. We combine existing knowledge, poorly understood data and new research into a coherent picture.
+
+1. **Accept and admit constraints**
+
+   Researchers at dxw do the best research we can within the constraints we have. We acknowledge and share the limits of our research and our findings. And we advocate for more research when it‘s needed to achieve the project outcomes.
+
+#### User research guidance
+
+The Playbook includes detailed guidance on [how we do user research at dxw](https://playbook.dxw.com/#/guides/how-we-do-user-research).
+
+The guide starts with the user research workflow, which describes the things that user researchers usually do on projects, and then provides further guidance and links to resources for specific topics.
+
+### Design
+
+#### Design team principles
+
+Designers at dxw follow these principles:
+
+1. **Democratise the design process**
+
+   Take into account, and value highly, the input of others in the design process. While we are ultimately responsible for design in a delivery team, we don’t work in isolation.
+
+1. **Value clarity in everything we do**
+
+   Use plain language in interfaces, writing and conversation.
+
+1. **Overlap with other disciplines**
+
+   Work closely with people that have different skills to you, in the knowledge that different perspectives make our decisions stronger and elevate our work.
+
+1. **Communicate constantly**
+
+   Never go missing. Our teammates always understand what we’re doing and why, because we’re all aiming for the same outcome.
+
+1. **Know we are not the user**
+
+   Do not assume to know how users of our services think or act. We acknowledge that things such as genetics, upbringing, religious and geographical culture, and past experiences make us all different. We work closely with our user researchers to gain understanding and insight about the people that use the things we design. _“One accurate measurement is worth more than a thousand expert opinions.”_ ~ Grace Hopper
+
+1. **Be educators**
+
+   Know that being open about our work, and helping others to understand our decisions and why we make them, benefits everybody.
+
+1. **Be kind**
+
+   Be tolerant, understanding, empathetic and compassionate. Look for opportunities to help and care for others. Putting people at the centre of everything will help you be a better designer.
+
+1. **Embrace questions**
+
+   Understand that when people ask questions and give feedback it is to make something better. If we can not articulate our decisions then we may not have made the best choice.
+
+1. **Ask questions**
+
+   Always ask questions and seek the truth;  when we understand the problem we can solve it. When things seem muddy take a step back and try and find the original intent or gaps in understanding. _“If I had an hour to solve a problem I’d spend 55 minutes thinking about the problem and five minutes thinking about solutions.”_ ~ Albert Einstein
+
+1. **Always assume the best intent**
+
+   We are passionate about what we do, but we are a team. When you have difficult conversations or feedback we should always assume that it is coming from a good place.
+
+1. **Tell stories**
+
+   When we talk about our work and why we do what we do, do not just state the facts. Inject some humanity into it; turn it into a story with a beginning, a middle,  and an end.
+
+### Development
+
+#### Development principles
+
+1. **Solve real user needs**
+
+   Good code starts with understanding, and is rooted in the real world. We work
+   in multi-disciplinary teams, but you’re not just there to churn out code. Get
+   involved in the research and design. Understand the needs of the users and
+   the constraints of the organisations we’re working with.
+
+   Ultimately, it’s about the user and their needs, not about technology.
+   Sometimes software is not the answer.
+
+1. **Own your code, but collaborate**
+
+   Having the opportunity to see a piece of work through to completion is a
+   great way to get stuff done, and for developers to grow. Take ownership of
+   your work to get it all the way through our development process to being used
+   by users.
+
+   Ownership gets stuff done, but collaboration makes it better. So involve the
+   rest of your team in your work: agree approaches, highlight tradeoffs and
+   seek out reviews. Get all your code reviewed by another developer to help us
+   ship better quality code, get the opportunity to learn new skills, and
+   increase the shared knowledge of our products. Request feedback, ask
+   questions and discuss code, but ultimately the author is responsible for
+   making changes.
+
+1. **Security is a user need**
+
+   Sometimes the simplest or easiest solution is not the most secure, and we
+   fight for our user’s safety and security, even when a client doesn’t agree.
+
+1. **Use simple, conventional technology**
+
+   By default, use straightforward technology and conventional approaches. The
+   services we built have to be maintained and iterated on by small, and
+   sometimes less experienced, teams. Keeping things simple ensures that is as
+   painless as possible.
+
+   Vary from convention only on the domain specific stuff, where it adds the
+   most value.
+
+1. **Build for quality and consistency**
+
+   Think about those who come after us. We build high quality systems with the
+   lowest possible maintenance burden. We write tests, use linters, follow
+   standards and conventions, and document our decisions. The things we build
+   should be set to thrive after we leave.
+
+1. **Improve with each iteration**
+
+   Always leave the codebase in a slightly better place than when you found it.
+   Look for opportunities to refactor difficult code, to improve documentation,
+   or to extract shared functionality.
+
+1. **Communicate clearly and frequently**
+
+   Help our future selves and others by recording the reasons for our actions.
+   Explain the changes you’re making to code through your commit messages and
+   pull requests. Explain the decisions you’re making about technology through
+   architecture decision records. Explain the tradeoffs you’re making in
+   planning and show and tells.
+
+   Use straightforward language, even when you’re dealing with complex technical
+   issues. Prefer to write it down over speaking it out, to ensure a lasting
+   record.
+
+1. **Be humble, supportive and open minded**
+
+   Assume other people on your team know things you don’t. Feel comfortable
+   saying “I don’t know”.
+
+   Assume you know things other people on your team don’t, but be prepared to be
+   wrong. Ask questions rather than giving instructions. Share your opinions and
+   experience openly with your team.
+
+   Question the obvious and test our assumptions. Listen to the client and the
+   users and their experiences.
+
+   Be non-judgemental – assume everyone did the best they could at the time,
+   with what they knew and the resources available.
+
+1. **Always learning. Always teaching**
+
+   Technology never stops, and the amount to know even for our limited stack is
+   huge, so we must learn and share. We teach each other through peer mentoring,
+   pairing and reviews.
+
+   Share what you learn on a project with the whole team so we can reuse
+   knowledge across projects. Encourage others in their learning.
+
+1. **Do the smallest amount of good work**
+
+   We aspire to regularly ship good code, and deliver it to the users as often
+   as possible. Delivering impact fast by shipping something real has a big
+   impact on the morale of the team and happiness of our clients and users.
+
+   Where you can, do less and deliver it sooner. Break down work into smaller
+   pieces. Descope anything that isn’t critical for a first version. Do a
+   minimum slice that works for some of your users. Anything to reduce the time
+   between get started on something and delivering it to users.
+
+   Work at a pace that suits the project. Hacky is sometimes fine. If you’re
+   working on prototypes then do only what you need to answer your questions.
+   Sometimes, if you’re working on critical production systems, you’ll have to
+   go slower. When that’s the case, it’s even more important to break down the
+   work into the smallest reasonable chunks, to demonstrate progress, to make
+   reviewing the changes as easy as possible, and to prove your assumptions.
+
+1. **Work in the open**
+
+   Be open by default. Code should be public unless there’s a good reason
+   otherwise. Changes to open source libraries should be contributed back to the
+   project. Dashboards should be public wherever reasonable.
+
+   The way we’re working should also be open to our clients. Work being done
+   should be represented in Trello boards that everyone can see. Communication
+   should be done in public Slack channels rather than direct messages. Openly
+   communicating about our work allows clients to see how we’re doing, and what
+   needs their attention, and gives everyone in the team context for the work
+   being done and decisions being made.
+
+### Commercial Operations
+
+We are the team that enables and encourages dxw to achieve its mission(s) and uphold its values.
+
+#### Commercial Operations Team Principles
+
+##### Things we do:
+
+1. We deliver the dxw business plan. In particular, we recruit the best people to meet our mission, manage our finances to allow sustainable growth, and track performance of objectives to measure ourselves.
+
+1. We are the front door for staff and clients. We help, support and enable dxw to meet its mission and uphold its values. We do this by being empathetic and put people over process.
+
+1. As commercial experts we take the burden away from our delivery teams, and make sure our people, as well as our suppliers get paid, whilst also ensuring our clients pay us on time.
+
+1. The unit of delivery is always the team, so we ensure staff wellbeing by providing a safe and inclusive environment. We also support our people to thrive in all stages of their careers, ensuring they have chance to continually learn, as well as excellent facilities and the right tools to enable them to succeed in their careers.
+
+1. We ensure dxw is compliant with all the relevant company and employment regulations, ensuring we have ISO 27001 accreditation, abide by GDPR guidelines and insurance.
+
+1. Commercial and business operations can be thankless, but to manage expectations we remain resilient and take responsibility for our work by effectively communicating about what we do and why we do it.
+
+##### Behaviours
+
+1. Empathetic to our users / staff / suppliers / clients.
+
+1. Support each other to support the team.
+
+1. Commercial accuracy and responsibility.
+
+1. We are balanced, organised and resilient.
+
+1. People over process, to maintain our unique, small-company, culture.
+
+1. We are proud of what we do and are confident enough to talk about it.
+
+1. We manage expectations by taking responsibility for our work and communicating what we do and why.
+
+1. We _are_ the company values.
+
+### Sales and marketing
+
+#### Sales and marketing team principles
+
+The sales and marketing teams at dxw follow these principles:
+
+1. **Start from solid foundations**
+
+   We work with potential and current clients to understand their needs and how we can deliver value - seeking out   opportunities for mutual growth.
+
+   We support our clients to make the right buying decisions, ensuring we focus on positive outcomes for users and making the most of the resources available.
+
+   We work closely with our delivery team so we can be open with clients about who will be available to do the work and realistic delivery timescales.
+
+1. **Build positive relationships**
+
+   We work in partnership with our clients, and are open and transparent at all times.
+
+   We remain responsible and accountable to both our delivery teams and clients, ensuring that we represent them in the right way and can deliver on our commitments.
+
+   We give our clients the opportunity and platform to talk openly about their experience of working with us.  We listen to what they’re telling us - about what’s going well and what we need to do differently - and constantly work to improve things.
+
+1. **Find the right work**
+
+   We welcome new opportunities, and actively seek input from the dxw team to help us decide whether an opportunity is ‘dxw shaped’.
+
+   We consider the ethical implications of the work - does it help to create better digital public services that make people’s lives better?
+
+   We will only take on work that’s a good fit for the team - that won’t put us under undue strain, where our team will be safe and we can have a positive relationship with our client.
+
+1. **Show the work and the team**
+
+   We’re an active part of the digital and tech community that’s working to build better public services.
+
+   We talk openly about what we’re doing and why, what we’re learning along the way and share our ideas and expertise. We blog all the time.
+
+1. **Have a clear voice**
+
+   Whenever we communicate - online or face-to-face - we’re always clear, to the point, friendly, and professional. You can rely on us to say it like it is.
+
+   We champion the things that matter to us and our clients. We’re bold and pragmatic and seek to influence change for the better in the way public services are created and delivered.
+
+1. **Communicate with a purpose**
+
+   When we communicate, it’s to explain what we’re doing and the impact of our work so our clients and potential clients understand our areas of expertise and how we can help them.
+
+   We’re open about our values and the way we work in dxw digital. We give our team members a voice because we’re proud of our diverse and inclusive culture.


### PR DESCRIPTION
Move the existing Professions content to an Our professions section at the end of the Playbook.
With the content here we can add more summary information for each profession with links to specific guides.
And when we're ready we can move the content for each profession into separate pages.