### PR TITLE
Move existing content into a Working here section

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -1241,19 +1241,663 @@ The sales and marketing teams at dxw follow these principles:
 
    We’re open about our values and the way we work in dxw digital. We give our team members a voice because we’re proud of our diverse and inclusive culture.
 
-## Meetings with your manager
+## Working here
 
-### One-to-ones
+### Managing your day to day work
 
-#### Purpose
+#### Working hours
+
+Our working hours are 10:00-18:00, Monday to Friday. Some people work different
+hours by arrangement. Anyone is free to do that as long as their hours of work
+don't make it hard for other people to get things done. For example, many people
+arrive earlier than 10:00 and leave earlier, which is generally fine.
+
+Each team has a short standup every morning, where we each tell the whole team about
+a single thing we will get done that day. If you think you're going to be late, you should
+let everyone know in the project Slack channel.
+
+Most developers have maintenance responsibilities, which they do during [ticket
+time](#ticket-time).
+
+We do our very best to [work at a sustainable pace](#work-at-a-sustainable-pace). But
+sometimes, when we're approaching a firm deadline or a launch, or a client is
+having an emergency, we work longer hours than normal. From time to time,
+there's an emergency that means we have to work during unsociable hours to solve
+the problem. Neither of these happen very often, but they are a normal part of
+life at dxw.
+
+Sending emails or posting in Slack outside of working hours can be a good way to get things off your mind,
+but it can create an unintended sense of urgency for the people who receive your message. Try to avoid creating
+that urgency when it’s not necessary. For example, by specifically saying that you don’t expect an immediate response.
+
+Unless they are actually urgent, you can ignore messages you receive
+outside of working hours and handle them when you are back at work.
+
+#### Working days
+
+##### Monday to Thursday
+
+**Client facing**: We charge clients “time and materials” for the work we do, based on a [per person day rate](https://assets.digitalmarketplace.service.gov.uk/g-cloud-10/documents/92768/432689933684667-sfia-rate-card-2018-05-23-1413.pdf). We generally schedule team members to work on particular projects for a whole sprint at a time, and track and bill that time in half days and whole days. Delivery leads work with the finance team to track and invoice the time of the team; having regularly patterned working helps the process to run as smoothly as possible, without confusion and without taking more time than needed. Any working arrangement needs to make it straightforward to track, report and invoice for your time.
+
+When working on a project we work as a single multi-disciplinary team. We’re often working on phases of projects where there’s a lot of unknowns and a lot of learning, so we use agile approaches and strongly favour being able to work together on problems. That’s often easier when co-located, particularly when working with clients, pairing, or participating in workshops. Any working arrangement needs to support active synchronous collaboration with the team.
+
+**Internal facing**: Internal facing roles, in which time is not billable to a client, have a more regularly structured five day working week. Everybody is encouraged to take part in Friday work, at least occasionally.
+
+##### dxw days
+
+We regularly come back together as a team to work on our own projects and processes, normally each Friday. These dxw days are important for us to maintain our strong culture and identity, separate from the clients we work for. Our sprints start on a Wednesday and end on the Tuesday two weeks later.
+
+#### Working from home
+
+Generally, we work either at our office or at client sites. But it's usually
+fine to work from home from time to time, or in order to complete a specific
+task. If you're working apart from your team, it is essential that you remain
+contactable and productive, and the onus is on you to be especially
+communicative.
+
+If you are working from home, you must record this as an absence in BreatheHR.
+There is a category, "WFH", for this purpose.
+
+#### Reporting your time
+
+Everyone who works on a client project at dxw is responsible for reporting the time they spend on projects. We usually work with our clients on a [time and materials basis](https://www.gov.uk/guidance/how-to-pay-for-digital-outcomes-and-specialists-services#time-and-materials), so it’s important we can accurately track and report how our time is spent on client projects.
+
+We use [10,000ft](https://app.10000ft.com/) to schedule our work, which helps us to forecast our capacity over future weeks and months in a reliable way.
+
+We track our time at the same level of granularity that we bill it – for almost everyone in the team, that’s half days or whole days.
+
+##### What to do when reporting your time
+
+When reporting our time, we follow these guidelines:
+
+* If what was scheduled matches reality, simply confirm this time.
+* If you worked on a named project (client or internal including "dxw Support"), that differs from the schedule, record your time as that.
+* If you worked on something else, leave the time blank or zero out what you were scheduled to work on.
+* If you were away on planned leave, confirm your time as "Out of office".
+* If you were off sick, record your time as "Sick".
+* If you had unplanned leave, record your time as "Out of office".
+* If you were away due to a regular day off, as part of your working pattern, leave the time blank or zero out what you were scheduled to work on.
+
+If you’re not doing client work, then unless you’re working on one of a handful of named internal projects or support, you don’t need to record your time against any other piece of work – the assumption is you’re doing valuable work, whether it’s learning, helping with recruitment or improving our tooling and processes, and we don’t need itemised time tracking to justify that.
+
+We’ve set up the platform, so that it understands individual team members’ working patterns. This means the team don’t need to worry about entering in their non working days.
+
+Our delivery leads lend a helping hand when delivery team members aren’t sure how to record their time – they’ve been doing this for a long while and have a well developed sense for it.
+
+#### Getting things you need
+
+Anytime you need to order something, notice a problem in the office (e.g. a broken chair or dripping tap) or you need some help with your laptop or the printer - there is a Slack channel for it. If in doubt, please speak to the Commercial Operations team and they’ll point you in the right direction.
+
+```
+#help-facilities
+#help-purchasing
+#help-travel
+#help-techsupport
+```
+#### Claiming expenses
+
+From time to time, some of us spend our own money at work. Most often, this is
+things like:
+
+* Train fares for unexpected travel
+* Refreshments purchased for meetings with clients
+* Stationery/materials, especially for workshops or events
+
+dxw will always pay expenses which are:
+
+* __Necessary__: We only expense things we need in order to be able to complete
+  our work
+* __Proportionate__: The total expense should be proportionate to the
+  work at hand. In general, we try to avoid spending lots of money. For example,
+  unless you have a good reason, don't get a cab to a meeting when you could get
+  a train.
+
+Wherever possible, it's best to check that expenses can be reclaimed before
+incurring them.
+
+We manage expenses using Xero. For more information about how to do this, see
+the [guide on claiming expenses](/guides/claiming-expenses)
+
+#### Calendars and documents
+
+We use Google Apps for Work to manage calendars, write and share documents.
+There is a dxw folder where we share most of the things we write. If you can't
+see it when you log in to Google Drive, you'll need to ask someone else to send
+you the link, and then click "Add to drive".
+
+When we write new things, we try to save them in a sensible folder within the
+existing structure.
+
+#### Internal tech support
+
+If you experience problems with the office printers, wi-fi, video conference
+set-up, Macs etc… You may send a message in the **#help-techsupport**
+Slack channel.
+
+#### Using a personal device at work
+
+Most of us use at least one personal device as part of our work, because it's
+more convenient than carrying lots of devices around. However, no one is
+obligated to use a personal device for work. If you need a dxw-provided phone,
+tablet or other device, please ask for one.
+
+Anyone who does use a personal device must take reasonable care to ensure that
+it cannot compromise dxw's security. This includes implementing prudent security
+measures, being mindful that your personal devices could be targeted as part of
+an attack on dxw or its clients. For example, you might receive an email to your
+personal email address designed to trick you into revealing a work-related
+password.
+
+Exactly what security measures are prudent may vary depending on the device and
+what you're using it for. Some good practice examples are:
+
+* Configuring screens to lock after a period of inactivity
+* Ensuring that
+  work-related data on the device is regularly backed up
+* Encrypting storage
+* Using good passwords and changing defaults
+* Avoiding connecting devices to untrustworthy networks (internet cafes,
+  security conferences, unencrypted (open) wifi networks, etc)
+* Disposing of your device securely when you no longer need it
+
+If you need to use a personal device but cannot take these sorts of measures,
+you should get permission first.
+
+#### Report a lost or stolen device used for work
+
+Submit an urgent ticket by sending an email to support-emergency@dxw.com stating which work device was lost or stolen and when the incident had occurred.
+
+Our support staff will be immediately notified, at any time of day.
+
+#### Data protection
+
+Though dxw doesn't control much personal data, our clients generally do. And
+some of it may be held on sites that we host. Everyone at dxw has a
+responsibility to keep that data safe, and process it in accordance with the [data
+protection
+principles](https://www.gov.uk/data-protection/the-data-protection-act).
+
+In particular, we:
+
+* Only process personal data as part of work on the service that we're
+  contracted to provide to a client
+* Don't access personal data unless we need to in order to do our jobs: don't
+  read people's personal data or private communications without good reason
+* We do not ever disclose people's personal data to anyone outside dxw unless
+  specifically instructed, and are satisfied that it is legal to do so
+
+If you have any questions about data protection, talk to Harry.
+
+#### Protective marking scheme
+
+Some information that we have is confidential. We use a protective marking
+scheme so that everyone understands how to handle this material, and who they're
+allowed to disclose it to. All of the documents and data we hold will fall into
+one of the categories below.
+
+* __Management-in-Confidence__: internal documents whose circulation within dxw
+  needs to be restricted.
+* __Company Confidential__: information owned by dxw
+  which would be of value to those outside the company, such as competitors, and
+  whose loss or theft would potentially damage the company.
+* __Client Confidential__ or __Commercial in Confidence__: information owned by
+  dxw or its clients, which needs to remain confidential between dxw and the
+  client.
+* __Unclassified__: information, which would not be of significant commercial
+  value to those outside dxw.
+
+Some of our clients also have protective marking schemes. For example, all
+central government bodies will apply the [Government Protective Marking System
+(GPMS)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/251480/Government-Security-Classifications-April-2014.pdf).
+If you are in possession of materials that are protectively marked using other
+schemes, treat them as company confidential.
+
+We take care to handle all data carefully, but when information is protectively
+marked, extra requirements apply.
+
+Because we value openness highly, we take care not to over-classify information.
+We don't protectively mark information unless there is a good reason to keep it
+confidential.
+
+##### Management-in-confidence
+
+This category is used only for dxw's most confidential information. For example,
+employment records, salary details and company strategy documents.
+
+Do not share any information with this marking with any person, whether internal
+or external to dxw.
+
+This information:
+
+* Must be clearly labelled or described as "Management-in-confidence"
+* When printed
+  * Stored only in a locked container
+  * Transported only via courier, recorded delivery or personally by dxw staff
+  * Destroyed by cross-cut shredding when no longer required
+* When digital
+  * Stored in an encrypted format
+  * Communicated only when encrypted or via an encrypted connection, unless emailed from one dxw.com address to another
+
+##### Company Confidential
+
+This category is used for information which should not be communicated outside
+dxw. For example, details about how we operate security controls or internal
+discussions about client work.
+
+Exactly the same controls apply to this information as detailed under
+Management-in-confidence, with the exception that Company Confidential
+information can be shared within dxw as required.
+
+##### Client Confidential or Commercial in Confidence
+
+This category is used for information which is disclosed to a limited group of
+people external to dxw, or which is unclassified information we have received
+from clients. For example, dxw proposals, presentations for pitches or planning
+documents.
+
+Unless otherwise specified, all unclassified information we receive from clients
+falls into this category.
+
+This information:
+
+* Must be clearly labelled or described as "Client Confidential" or "Commercial in Confidence"
+* When printed:
+  * Stored out of sight
+  * Destroyed by cross-cut shredding when no longer required
+* When digital:
+  * Stored in an encrypted format when on exchangeable media or a mobile device
+
+As a rule of thumb, label a document as Client Confidential if it mostly
+contains the client's confidential information, or Commercial in Confidence if
+it mostly contains dxw's.
+
+##### Unclassified
+
+Anything not captured by the sections above is unclassified. Examples are
+external marketing material, general emails and letters.
+
+Beyond a general duty to treat information carefully, unclassified information
+is not subject to any specific restrictions.
+
+#### Email signature
+
+Name<br>
+Job Title<br>
+name@dxw.com<br>
+Twitter handle - if you’re comfortable to share<br>
+Mobile - if you’re comfortable to share<br>
+
+www.dxw.com :: 0345 2577520 :: @dxw :: creating better digital public services
+
+#### Email autoresponder
+
+If you require an out of office message on your email account please send
+your request to support@dxw.com with the subject title **Email Autoresponder**
+which must include start date, the contact details for another member of the
+team for any urgent queries, and return date to be added to our mail server.
+
+**Note:** please use Helvetica or Arial as the font in your emails.
+
+### Your pay, pension and other benefits
+
+All perks and benefits are available to the dxw team after the successful passing of their probationary period.
+
+#### Changes to your details
+
+Please tell us promptly if your name, address, telephone number, next of kin details or banking
+details change.
+
+#### Cost of living raise
+
+dxw will institute a cost of living raise each year on 1st April. The percentage
+will be set by the [CPI Index](https://www.ons.gov.uk/economy/inflationandpriceindices)
+as of 1st April each year.
+
+* If you have passed your probation, you will receive your raise in the April payroll.
+* For those team members who joined prior to 1st April of that year, but haven't yet
+  passed probation, you will receive your raise in the month you successfully complete it
+  and it will be the same percentage as of 1st April CPI that year.
+* If you joined on or after 1st April (that year), you will not be eligible for a cost
+  of living raise until the following April.
+* If you are leaving during April you will not receive the cost of living raise.
+
+#### Pensions
+
+dxw provides a pension which is operated by Aviva. Once you have passed your 3
+month check in, you will be auto enrolled into the scheme, receive details by
+post of the necessary employer/employee contributions and have the option to set
+your percentage or opt out.
+
+dxw will match any contribution up to 5%.
+
+Your contribution will be relief at source, with 0.8 deducted from your monthly
+salary and the additional 0.2 added from tax relief.
+
+For more details on Relief at Source, please visit the [Aviva website](
+https://www.aviva.co.uk/retirement/news-views/report/making-sense-of-tax-relief-on-pension-payments/).
+
+#### Holiday
+
+If you want to take time off:
+
+1. Discuss the dates with your team and delivery lead
+
+   This gives them a chance to manage any impact it might have on the wider team and the project.
+
+1. Request the holiday through BreatheHR
+
+   We use BreatheHR to track who's off and when, so we can plan for it. Your line manager can then see and approve your request.
+
+1. Add your holiday to your Google calendar
+
+   If someone is trying to find out where you are, or when you're available, the first thing they'll check is your calendar.
+
+   When you are on a client project, you may also need to add your holiday to a shared or team calendar. Check with your delivery lead.
+
+Your line manager will normally approve requests that are for 10 days or less and made at least 4 weeks in advance. Anything longer or requested with less notice will need to be managed to understand its impact on client, team or personal work.
+
+When your planned leave has been approved, update the schedule in 10,000ft to reflect this. This helps us to look ahead and is recorded as “Out of office". Each member of our delivery team uses the tool to record the days they work on client projects on a weekly basis.
+
+There is more information about dxw's holiday arrangements in your contract of employment.
+
+#### TOIL (Time off in lieu)
+
+Where possible we try to keep a sustainable pace of work and avoid working outside normal hours; occasionally this might not be possible.
+
+##### How is TOIL calculated?
+
+TOIL (time off in lieu) is awarded when you work over and above your contracted working hours continuously for a period of time or when you attend/travel to an event outside of your contracted working hours. TOIL should be agreed with your delivery lead or line manager ahead of doing the extra work.
+
+We encourage you to use your TOIL within the two weeks of extra work or event attended as it's meant to be for resting and making up for working  at a sustainable pace.  We know this may not be feasible in every case so please speak to your Line Manager or a member of the HR team if you have any questions.
+
+There are two options of how to use your TOIL, you can calculate the amount of hours you have accrued (ie half a day) and take it off at once or take a couple of hours a day spread over a period of time. Planning when you’ll take TOIL is important, particularly if you’re working on a billable project so please speak to your Delivery Lead before doing any overtime and arrange when you’ll be able to take the time back.
+
+##### How to request TOIL?
+
+Using BreatheHR similar to the way that you request holiday there is a TOIL drop down, please write a note as to why you are requesting the leave and this will be approved by a member of the HR team. Please note this will not deduct from your holiday allowance shown on your BreatheHR dashboard.
+
+#### Sickness
+
+If you are sick, you must let us know by 10:00, or as soon as is reasonably
+practical. Do not come to the office. If you come to the office when sick, you
+may be sent home again.
+
+If you're sick but able to work, you can work from home. Everyone at dxw should
+have a laptop, and should generally take it home with them in case it's needed.
+If you're sick and at home but don't have your laptop, it can be couriered to
+you.
+
+When you return to work, you must check that your sickness has been correctly
+recorded in BreatheHR, and update it if necessary. If you're sick for more than
+a week, you'll also need to provide a [fit
+note](https://www.gov.uk/government/publications/the-fit-note-a-guide-for-patients-and-employees).
+
+If you're sick on more than 10 occasions or for more than 10 days over a
+12-month period, we'll invite you to an absence meeting to discuss your
+situation. We may agree with you an action plan and/or a review period. We may
+seek medical advice. Should your attendance fail to improve after a three-month
+period, we will invite you to a further absence meeting to discuss your
+situation. In this meeting we will also give consideration to your possible
+dismissal.
+
+We'll also invite you to an absence meeting if you're off sick for more than
+three weeks on a single occasion. In addition to the above, we will seek to
+support your return to work and discuss with you any temporary or permanent
+adjustments which may assist you. If you are unable to return to work in your
+current role we will consider if there is a suitable alternative role. If we are
+unable to reach an agreement that will permit you to return to work, we will
+give consideration to your possible dismissal.
+
+We will always only consider dismissal after we have exhausted all other
+reasonable options.
+
+#### Compassionate leave
+
+If you need to take compassionate leave, let your line manager and a member of the HR team know, so we can support you in the right way. If you are on a project, we can then work with your delivery lead to manage the impact on the team.
+
+To record the compassionate leave in BreatheHR, choose Other as the Type of Leave, and choose Compassionate as the Reason.
+
+#### Parental leave
+
+While many terms around parental leave are gendered, gender is not a factor in what
+leave you are entitled to. What matters is whether or not you are pregnant.
+
+##### If you're pregnant
+
+If you're pregnant, you’ll probably be entitled to [Statutory Maternity Leave (SML)
+and Statutory Maternity Pay (SMP)](https://www.gov.uk/maternity-pay-leave/leave),
+which is funded by the government. They will pay you 90% of your normal salary
+for the first six weeks of your leave.
+
+Assuming you are entitled to SMP (almost everyone is), dxw will also pay you 90%
+of your salary for the second six weeks of your leave. This contribution
+is called Occupational Maternity Pay (OMP). Taken together, this means that
+you’ll have twelve weeks of leave on 90% of your normal salary.
+
+To be eligible for OMP, on returning to work you will need to stay at dxw for at
+least three months full time (or proportionately longer if working part-time).
+If you decide not to, you will have to repay any OMP you received.
+
+When you know you are pregnant please do tell us as soon as possible, so we can
+check that your working arrangements are safe for you and also ensure you are
+paid for time off for antenatal appointments.
+
+##### If you're not pregnant
+
+If your partner is pregnant, you are adopting, or you are having a baby
+through surrogacy, you’ll probably be eligible for [Statutory Paternity Leave (SPL)
+and Statutory Paternity Pay (SPP)](https://www.gov.uk/paternity-pay-leave). SPL
+may be taken for one or two consecutive weeks, between the date of birth and 56
+days afterwards. SPP is £145.18 per week.
+
+If you qualify for SPL and SPP, dxw will instead pay you your normal salary for
+three weeks of paternity leave. If you want to take more than three weeks of
+leave you can use [shared parental leave](#shared-parental-leave).
+
+##### Shared parental leave
+
+If you're having a baby, adopting a child, or having a baby
+through surrogacy, you may be eligible for [Shared Parental Leave and
+Pay](https://www.gov.uk/shared-parental-leave-and-pay). If you're interested in
+taking this up, please talk to the People Manager.
+
+##### Keep in touch (KIT) days
+
+You have 10 paid KIT days to take during your parental leave if you wish to come in
+for departmental meetings, events or just to spend some time in the office.
+
+Any bank holidays that you miss while on parental leave will be added to your
+holiday entitlement when you return to work.
+
+#### Childcare Vouchers
+
+The Government closed the Childcare Vouchers scheme to new entrants on 4th October 2018. This means we are no longer able to add new members to the voucher scheme with Busy Bees.
+
+The government has introduced new ways to help parents with childcare costs which you access directly: [https://www.gov.uk/get-tax-free-childcare](https://www.gov.uk/get-tax-free-childcare)
+
+For more information, please speak to the People Manager.
+
+#### Flexible working
+
+Our policy is informed by the way we work and the way we charge clients for our time.
+
+##### Overall requirements
+
+**Client facing**: Any working arrangement needs to allow you to participate in most Fridays and be around for the important start-of- and end-of-sprint ceremonies.
+
+**Internal facing**: Working arrangements for these roles are slightly more flexible as the delivery needs listed above are not relevant.
+
+##### Part time working
+
+The normal working pattern is 5 days per week, Monday–Friday.
+
+**Client facing**: We’re happy to talk about a 4-day week, on the basis of a fortnightly pattern to accommodate our Monday–Thursday billing week and attending some Fridays. It may be possible for some roles to work a 3 day week due to the nature of the role potentially not being full-time on a single project, this would be dependent on a number of contextual factors and discussion with the team. We’re unable to support a 3-day (or fewer) week for all other roles due to the overheads for scheduling.
+
+**Internal facing**: We’re happy to talk about part time working for any number of days, dependent on the role.
+
+Part time hours spread over 5 days, e.g. working 21 hours across a full week, or roughly 4 hours a day, may be possible for internal facing roles after discussion, but is likely a no for client facing roles.
+
+Salary and holiday allowances (including bank holidays) will be prorated for part time roles.
+
+For example, when working a 4 day week, the pro rata leave allowance will be 20 days per year of annual leave and 6.5 bank holiday days, giving a total leave allowance of 26.5 days. Bank holidays that don’t fall on a non-working day must be booked as annual leave.
+
+##### Core and non-core hours
+
+Everybody is expected to work seven hours a day. Normal office hours are 10am–6pm.
+
+If you’d prefer to start a little earlier and finish a little earlier (say 9am–5pm), this is definitely OK and can happen without any formal discussion for all roles.
+
+If you’d prefer your working hours to start after 10am or finish before 5pm (still keeping to seven hours), we’re happy to discuss this and either **might** be possible. The impact of this would be less for internal facing roles than for client facing roles, but both would require a discussion.
+
+Salary and holiday allowances would remain the same.
+
+##### Compressed hours
+
+Compressed hours involves working your full hours in fewer days. For example: 35 hours in 4 days, 9.30am–6.45pm.
+
+We don't offer compressed hours for client-facing roles due to the complications for the way we bill our time and present our services to clients.
+
+We are happy to have a discussion about compressed hours for internal-facing roles but cannot guarantee this would be an option.
+
+35 hours in 3 days, for example, is a no across all roles. It goes against our encouragement of [sustainable pace](#sustainable-pace).
+
+For working patterns with the same number of hours each day, holiday allowance can be treated the same as for [part-time roles](#part-time-working). For working patterns with varied hours, the annual allowance for both holiday and bank holidays should be counted in hours (231 hours per year) and bank holidays that fall on working days must be booked as leave.
+
+##### Remote working/location
+
+Generally, we work either at our office or at client sites.
+
+We’re happy to support working from home from a logistical or well-being related perspective. While we don’t support fully-remote roles (legacy arrangements being the exception), we can look at anything from 1–3 days per week following a discussion.
+
+If you need to work from home for a one-off thing then that doesn’t require contractual arrangement – just talk about it with your team before the day, make sure you note it in your calendar and include it in your standup note that day.
+
+##### Requesting a change of working arrangement
+
+If you would like to discuss a change to the standard working pattern, you can either speak to your Head-of directly, or, contact the People Team to facilitate and support this conversation by phone, email, slack or in one of our bi-weekly HR surgeries. In this initial conversation, we will discuss your request, look at the impact on the team and your work, agree the best time for this arrangement to begin and how it will be communicated to those necessary.
+
+If you have an alternative working arrangement, you should make sure it’s reflected in your calendar so the rest of the team can be confident in knowing when you are and aren’t around.
+
+#### Grievances
+
+If you have a grievance about your employment or a complaint about another
+member of staff, talk to the Managing Director as soon as possible.
+
+The first step is to discuss the problem to see if it can be quickly resolved.
+
+If this discussion does not satisfactorily resolve the problem, you should put
+details of your grievance in writing and send it to the Managing Director. They
+will arrange a meeting to discuss the matter, at which you may be accompanied by
+a colleague or trade union official. Following this discussion the Managing
+Director will provide a written response.
+
+If you disagree with this response or the matter remains unresolved, you may
+appeal by respond in writing. A further meeting will be arranged and the
+Managing Director will again respond in writing. This decision will be final.
+
+#### Disciplinary procedure
+
+If you do something that we feel constitutes misconduct, or your performance in
+your job has been poor, we'll talk to you about it. Hopefully, there's just been
+some misunderstanding, or some problem that's easy to solve and won't recur.
+Formal action will not be taken without careful investigation of the facts.
+
+If we feel it's appropriate, we may verbally warn you, explaining what has been
+unacceptable and what you need to do to improve your conduct or performance.
+
+If your conduct or performance fails to improve following a verbal warning, or
+if the matter is serious enough that a verbal warning is not appropriate, we may
+hold a disciplinary meeting at which you may be accompanied or represented by a
+colleague or trade union official. Following this meeting, we may:
+
+* Conclude that no misconduct has taken place, or that there is no poor performance
+* Issue you with a written warning, which will explain:
+  * The nature of the misconduct or poor performance
+  * The change to your behaviour or performance that you need to make
+  * The time within which the change needs to be made
+  * The consequences of not making the change (for example, dismissal)
+* In cases of gross misconduct, dismiss you without notice
+
+If you disagree with the outcome of this hearing, you may appeal against the
+decision. You must do this in writing. If you do so, your appeal and the
+circumstances of your case will be reviewed by a member of staff who has not
+been involved in your case before. That member of staff and the Managing
+Director will then meet to discuss your case, and will either uphold the outcome
+or schedule another disciplinary meeting. dxw's decision following that meeting
+will be final.
+
+### Supporting your development and wellbeing
+
+#### People manager and HR surgeries
+
+The bi-weekly HR surgeries are there to give an opportunity for members of the team to discuss matters they might not feel able to raise with buddies/delivery leads/line managers or that are specialist to the HR function in dxw.
+
+The list is not exhaustive but some topics might include:
+
+* Holiday
+* Sickness
+* Pay
+* Expenses
+* Parental Leave
+* Accessibility
+* Probation
+* Pensions
+* Occupational health issues
+* Contractual matters
+* Working patterns/locations
+* Training and career progression
+* Diversity
+* Inclusivity
+* Stress management
+* Interpersonal issues
+* Bereavement
+* Grievance and disciplinary matters
+* Facilitation/scheduling of conversations with Directors/heads-of, such as Salary Reviews
+
+Bookable slots are available on Wednesdays and Fridays at 11am but the People Manager’s door is always open.
+
+#### Line managers
+
+Line management at dxw is not about hierarchy, it’s about providing professional guidance and support.
+
+Line managers ensure that team members are clear about their roles and responsibilities at dxw, and how well they are doing at achieving them.
+
+Individuals should be proactive in taking responsibility for their own development, but line managers will provide advice and support to help team members meet their agreed short and long term goals.
+
+HR support line managers with advice and guidance on recruitment, onboarding, probation, performance, sickness and any other specialist knowledge.
+
+You can find out who your line manager is in BreatheHR on the summary section of your profile page.
+
+##### Line management principles
+
+###### Communicate clearly
+Communication is a two-way process and it is important to check understanding and confidence, and value the other person in decision-making. Explaining the task and its objectives clearly means people know what’s expected of them and the part they play. It empowers them to take responsibility and own how they approach the work.
+
+###### Recognise achievement and celebrate success
+A simple ‘thank you’ shows someone that what they have done is appreciated, and is hugely motivating. Celebrating major, and minor, achievements is an important part of our culture at dxw. It builds team spirit and morale.
+
+###### Guard our values
+Lead by example. The actions and behaviours of line managers must always demonstrate our dxw values. We should always hold ourselves accountable to our values, and encourage the same in all of our colleagues, including those we line manage.
+
+###### Continuous constructive feedback
+Find out how each of your team members prefers to receive feedback, and develop an approach which reflects that.  Ongoing positive and constructive feedback is essential if someone is to feel valued, learn from their experiences and become better at what they do.
+
+###### Be honest
+Being honest means telling the truth and being consistent in what you say and who you say it to. Telling things as they are, while being sensitive to the situation and individual, ensures that people know where they stand and will help to build mutual trust and respect.
+
+###### Wellbeing
+Line managers look out for the health and wellbeing of the team. They are responsible for carrying out dxw's duty of care to its people.
+
+#### One-to-ones with your line manager
+
+##### Purpose
 
 For your manager to help you with your personal and professional development, your wellbeing, and to build a trusting relationship between the two of you.
 
-#### Overview
+##### Overview
 
 These meetings are about you; ideally you will feel happy driving the meeting. If you’re not confident doing this, or are unsure how best to approach it, your manager will help you to get there.
 
-#### Agenda and topics
+##### Agenda and topics
 
 Coming to your 1:1s with a list of things you’d like to discuss will help you make the most of the time. Some things you might find productive to talk about include:
 
@@ -1264,25 +1908,110 @@ Coming to your 1:1s with a list of things you’d like to discuss will help you 
 - **Interpersonal issues:** Having problems with a coworker? Your manager can help mediate or coach you through how to deal with the issue.
 - **Retrospection:** If at any time you feel like your 1:1s aren’t particularly productive or helpful, or you’d like to change something about them, don’t hesitate to bring this up with your manager.
 
-#### Frequency
+##### Frequency
 
 1:1s should happen at least once per fortnight. Where possible they’ll be face-to-face, either in the office or out for a walk, or a coffee. Where that’s not possible, remote is perfectly fine. There’ll always be a Google Meet link in the calendar invite.
 
 If you need to reschedule your 1:1, let your manager know at the earliest opportunity.
 
-#### Meeting length
+##### Meeting length
 
 An hour or so, at least once every two weeks, is a good standard to aim for. If you meet weekly, a little shorter is fine.
 
-#### Additional resources
+##### Additional resources
 
 Here's [a template for helping to prepare for a 1:1, and making notes during it.](https://docs.google.com/document/d/1rCoFGtvbBI2FYhp-4EYMRokB--E8RHs_BleQqNwD0Rk/edit#) Feel free to make a copy and alter it according to your own needs.
 
-And here’s a great article on [7 ways to prepare for an effective one-on-one meeting with your manager.](https://knowyourteam.com/blog/2018/01/03/7-ways-to-prepare-for-an-effective-one-on-one-meeting-with-your-manager/)
+Here’s a great article on [7 ways to prepare for an effective one-on-one meeting with your manager.](https://knowyourteam.com/blog/2018/01/03/7-ways-to-prepare-for-an-effective-one-on-one-meeting-with-your-manager/)
 
-## Recruitment
+#### Personal learning and development allowance
 
-### Basics
+We have an annual allowance of £750 and up to 4 days per person, to be used for a range of professional and personal development activities like workshops, short courses or conferences.
+dxw pays for the event ticket, travel, and accommodation, but you will need to cover your own costs for food, drink and supplementary equipment.
+
+You should discuss your training plan with your line manager, they will help you identify potential areas for development and support you to find suitable events or training.
+
+You may also use the allowance to attend a non role based conference or event focused on improving your health and wellbeing. You will receive two days off for this, and can top up the time from your annual leave allowance.
+
+Attending conferences and events that are not related to your role, is a taxable benefit. As your employer, we will make the declaration, HMRC will then adjust your tax code accordingly to collect the tax via PAYE.
+
+##### How it works
+
+The allowance will be available to everyone once they have completed their probation period, within the dxw financial year which runs from the start of July to end June. It will be pro-rata for staff who work part-time. If you don’t spend your allowance within the financial year, it cannot be carried over.  We will start afresh each year, as part of our annual budgeting cycle. Your allowance is counted as being spent at the time of purchase rather than at time of use; for example, if you buy a conference ticket in May for an event in July the same year, the deduction will be made to the budget for the financial year that May falls within.
+
+Any events (paid, free, speaking, etc) you attend should be logged in BreatheHR as a training request. If they do require payment, please include weblinks and an estimate of the ticket, accommodation and travel costs (up to the maximum of £750, though you are welcome to pay the difference for more expensive events). This helps manage the annual budget and will give you a great view of what you have attended in the year.
+
+It’s ok for members of the team to go together, but we need to ensure that training days have the lowest impact on client work, so there may be times we need to consider whether your request is possible. Our Director of Delivery will help with prioritisation in those circumstances.
+
+We know that lots of training isn’t paid for, and involves things like coaching and mentoring, learning from colleagues, being an active part of networks, and other self-directed learning. We will encourage and support people who want to use unbilled days for different types of professional development.
+
+If appropriate, it’d be great if you would talk about your experiences in a blog post or bikeshed - sharing good events and useful training will give others the opportunity to attend.
+
+At the end of each financial year we will review our financial position with the intention of increasing the annual allowance.
+
+If you have any questions, please contact the HR team.
+
+#### Book purchase
+
+If there is a book relevant to your work that you would like to read, make a request through the #help-purchasing slack channel and the Bus Ops team will buy it for the library.
+
+#### Cycle to work scheme
+
+dxw operates a cycle-to-work scheme, which may allow you to purchase a bicycle
+at reduced cost. If you would like to take this up, please register
+[on the cycle scheme website](https://www.cyclescheme.co.uk/18eb71)
+
+#### Eyecare vouchers
+
+dxw provides eyecare for the team via a voucher system run by ASE Corporate Eyecare Ltd and Boots.
+
+Details of what the wellbeing voucher offers can be found here: [Eyecare for Wellbeing](https://www.eyecareplans.co.uk/corporate-eyecare/eyecare-for-wellbeing/).
+
+[Apply for a wellbeing eyecare voucher](https://gw.eyecareplans.co.uk/dxwe12q2415d3df)
+
+#### Backpack and other personal equipment
+
+dxw will pay for the equipment needed to enable you to work comfortably and safely. dxw also offers a budget of £25 towards a work backpack. Use the help-purchasing Slack channel to request any equipment you need, or talk to anyone in business operations if you are unsure if a purchase will be covered.
+
+#### Support paths
+
+##### Helpers
+
+When you join dxw you will be assigned a helper. This person will work closely with you for at least your first 4 months. They will do a similar job to you, help you meet members of the wider team, catch up with you on at least a 3/6/12 week basis to ensure you are receiving everything you need, and will NEVER get bored of your questions!
+
+If you feel that you’re not getting as much time with your helper as you’d like, please speak to the People Manager.
+
+As a helper, you will be vital in ensuring you have the regular catch ups - if you are finding it hard to schedule them, please do talk to Bus Ops.
+
+For more information on being a helper, please see the [checklist](https://docs.google.com/document/d/1Dc3IRZ_ze7QzMQTHO70ZC6hU8cig5ds7LN2MoHmPBe8/edit) or speak to the People Manager.
+
+##### Buddies
+
+Once you have passed your 4 month probation, we would like you to choose a buddy within the company to support you.
+
+We recommend this person **doesn’t** work directly with you, someone in a different role and that you don’t work closely with on projects, as this will give you a second pair of ears and a whole new set of experiences to draw on.
+
+This is not mandatory, just recommended and similarly not everyone may wish to be a buddy - don’t be afraid to ask or say no. It can be reciprocal but doesn’t have to be.  Also, if you feel that a change of buddy would benefit you for whatever reason or that you’re no longer able to be a buddy, this should also not be an awkward situation. If you have any concerns, have a chat with the People Manager.
+
+The buddy system is there to help us all improve, to make sure we're doing the right kind of work and to check that we're dealing with practical problems we're facing. It's not line management, so it's not the right place to talk about holiday, salary, sickness, absence or anything disciplinary. If you need to talk about those things, talk to the People Manager.
+
+If you want to know more about how the buddy system works, how often to meet and suggested discussion topics, see the buddy [crib sheet](https://docs.google.com/document/d/1PBKwPLFsGWUUzeYAObcFLQJyTPknkLhm2HrbuHwxelU/edit?usp=sharing). This shouldn’t be a huge time commitment, ideally just a pleasant Friday meet up.
+
+##### Your delivery Lead (for those on client work)
+
+There will be opportunities within the delivery team to raise any issues or concerns you might have e.g. retrospectives or planning sessions. As well as this, or if you’d prefer to talk one on one, the delivery lead working on the project will be available to provide support and guidance.
+
+##### Directors & heads-of
+
+All members of the Directors and heads-of team are here to help answer any questions you might have. Your own Director and/or Head-of profession or location is there to provide support on matters relating to dxw and your career with us, as well as profession specific questions. Similarly, they are here if you need to escalate any job-related concerns.
+
+##### Our Managing Director, Dave
+
+At dxw, all doors are open if you need to raise a concern or just have a chat - this includes our MD. Dave is always available to discuss any questions you have about the company and its future. Equally, if you feel you need to escalate anything to him, don’t hesitate to get in touch. Dave's diary is open and you can see it on Google Calendar. If you would like to schedule some time with him, please feel free to book something.
+
+### Hiring new people
+
+#### Basics
 
 We use [Workable](https://dxw.workable.com) for recruitment, to help us stay
 organised and keep in touch with candidates.
@@ -1296,7 +2025,7 @@ interest in us, and that their attention is valuable. So we do our best to be
 responsive, human and open. It's particularly important to give unsuccessful
 candidates good, thorough feedback about why we haven't made them an offer.
 
-### Job descriptions
+#### Job descriptions
 
 Before we decide to advertise a new job, we write a job description. This helps
 us make sure we all agree on what we need, and helps candidates to know if their
@@ -1315,7 +2044,7 @@ for the work day. The skills and personal qualities need to be things that we
 can have a go at understanding by asking questions and observing a candidate's
 behaviour.
 
-### How we find people
+#### How we find people
 
 The first way we find people is through our networks. We look for people we
 know. Everyone who is willing tweets about the job and shares it on Facebook and
@@ -1330,7 +2059,7 @@ what we're doing, and being open about our culture, work and process. We accept
 [general applications](https://www.dxw.com/jobs/general-application/) from
 people who are interested in dxw but who don't fit an open job.
 
-### Review applications
+#### Review applications
 
 All applications arrive via Workable. We review these applications as a team to
 decide who to take forward.
@@ -1340,7 +2069,7 @@ by the candidate and decide if it is likely that the applicant has the skills,
 experience and personal qualities that we need. If it is likely, we progress
 them to the next stage.
 
-### Screening
+#### Screening
 
 The purpose of the screening is to:
 
@@ -1383,7 +2112,7 @@ just make a decision. If you think it's quite likely that they have the skills,
 experience and personal qualities that we need, you should take them through to
 an interview.
 
-### Interviews
+#### Interviews
 
 Candidates who have a successful screen will be offered an interview. This is an
 hour long with two members of the team.
@@ -1429,7 +2158,7 @@ The work day interview is exactly the same as the first interview, but with
 different members of the team and different questions. Usually, it happens in
 the first hour of the work day.
 
-### Work day
+#### Work day
 
 TODO. This section to cover:
 
@@ -1441,7 +2170,7 @@ TODO. This section to cover:
 * Discussing the results
 * Offer if we are sure they are right
 
-### Offer, joining and probation
+#### Offer, joining and probation
 
 TODO. This section to cover:
 
@@ -1452,20 +2181,25 @@ TODO. This section to cover:
 * The probation period, meeting and expectations
 * ...more things.
 
-### Returners' programme
+#### Returners' programme
 
 dxw is proud to offer return to work opportunities for experienced hires who are looking to re-enter the workplace after an extended period of time away.
+
 We’re running a pilot to begin with to see how this works for us and the people joining us. We’ll start by taking on one or two people for 3 to 6 months - depending on the role and circumstances. There’s potential to become a permanent member of the team at the end of the placement, but this isn’t guaranteed.
+
 Initially this opportunity will only be offered within our London team, with a view to including our Leeds office as the team there grows.
 
-#### Who supports you?
+##### Who supports you?
 
 You will be supported by our people team from the point of application.
+
 If you’re invited into our recruitment process, it will consist of a one hour interview followed by a collaborative activity with the team which will be sent to you 24 hours in advance so you have time to prepare.
+
 The interview will be an informal, semi-structured conversation where there will be the opportunity for us to learn more about you and your experience and, just as importantly, for you to get a feel for what it’s like to work at dxw.
+
 If you join us, you’ll be continuously supported by our people team, a line manager and a mentor within the same field. You‘ll have regular check ins with the team where you can speak openly about anything that’s on your mind.
 
-#### Client facing role
+##### Client facing role
 
 For client-facing roles we’ll start billing your time back to the client when we feel the time is right. This will be something we discuss openly during the recruitment process and through your regular check ins.
 
@@ -1474,779 +2208,6 @@ For client-facing roles we’ll start billing your time back to the client when 
 We’re also offering internal facing roles, for example, in our busy commercial and marketing teams who also support our sister company, Tradecraft. These roles are not billed back to our clients.
 
 If you think this might be for you, please apply through our jobs page.
-
-## Working arrangements
-
-### dxw Support Structures
-
-#### Practical day to day support
-
-Anytime you need to order something, notice a problem in the office (e.g. a broken chair or dripping tap) or you need some help with your laptop or the printer - there is a Slack channel for it. If in doubt, please speak to the Commercial Operations team and they’ll point you in the right direction.
-
-```
-#dxw-facilities
-#dxw-purchasing
-#dxw-travel
-#dxw-techsupport
-```
-
-#### Helpers
-
-When you join dxw you will be assigned a helper. This person will work closely with you for at least your first 4 months. They will do a similar job to you, help you meet members of the wider team, catch up with you on at least a 3/6/12 week basis to ensure you are receiving everything you need, and will NEVER get bored of your questions!
-
-If you feel that you’re not getting as much time with your helper as you’d like, please speak to the People Manager.
-
-As a helper, you will be vital in ensuring you have the regular catch ups - if you are finding it hard to schedule them, please do talk to Bus Ops.
-
-For more information on being a helper, please see the [checklist](https://docs.google.com/document/d/1Dc3IRZ_ze7QzMQTHO70ZC6hU8cig5ds7LN2MoHmPBe8/edit) or speak to the People Manager.
-
-#### Buddies
-
-Once you have passed your 4 month probation, we would like you to choose a buddy within the company to support you.
-
-We recommend this person **doesn’t** work directly with you, someone in a different role and that you don’t work closely with on projects, as this will give you a second pair of ears and a whole new set of experiences to draw on.
-
-This is not mandatory, just recommended and similarly not everyone may wish to be a buddy - don’t be afraid to ask or say no. It can be reciprocal but doesn’t have to be.  Also, if you feel that a change of buddy would benefit you for whatever reason or that you’re no longer able to be a buddy, this should also not be an awkward situation. If you have any concerns, have a chat with the People Manager.
-
-If you want to know more about how the buddy system works, how often to meet and suggested discussion topics, see the buddy [crib sheet](https://docs.google.com/document/d/1PBKwPLFsGWUUzeYAObcFLQJyTPknkLhm2HrbuHwxelU/edit?usp=sharing). This shouldn’t be a huge time commitment, ideally just a pleasant Friday meet up.
-
-#### HR
-
-The bi-weekly HR surgeries are there to give an opportunity for members of the team to discuss matters they might not feel able to raise with buddies/delivery leads/line managers or that are specialist to the HR function in dxw.
-
-The list is not exhaustive but some topics might include:
-
-* Holiday
-* Sickness
-* Pay
-* Expenses
-* Parental Leave
-* Accessibility
-* Probation
-* Pensions
-* Occupational health issues
-* Contractual matters
-* Working patterns/locations
-* Training and career progression
-* Diversity
-* Inclusivity
-* Stress management
-* Interpersonal issues
-* Bereavement
-* Grievance and disciplinary matters
-* Facilitation/scheduling of conversations with Directors/heads-of, such as Salary Reviews
-
-Bookable slots are available on Wednesdays and Fridays at 11am but the People Manager’s door is always open.
-
-#### Delivery Lead (for those on client work)
-
-There will be opportunities within the delivery team to raise any issues or concerns you might have e.g. retrospectives or planning sessions. As well as this, or if you’d prefer to talk one on one, the delivery lead working on the project will be available to provide support and guidance.
-
-#### Line Managers
-
-Line management at dxw is not about hierarchy, it’s about providing professional guidance and support.
-
-Line managers ensure that team members are clear about their roles and responsibilities at dxw, and how well they are doing at achieving them.
-
-Individuals should be proactive in taking responsibility for their own development, but line managers will provide advice and support to help team members meet their agreed short and long term goals.
-
-HR support line managers with advice and guidance on recruitment, onboarding, probation, performance, sickness and any other specialist knowledge.
-
-You can find out who your line manager is in BreatheHR on the summary section of your profile page.
-
-##### Line management principles
-
-###### Communicate clearly
-Communication is a two-way process and it is important to check understanding and confidence, and value the other person in decision-making. Explaining the task and its objectives clearly means people know what’s expected of them and the part they play. It empowers them to take responsibility and own how they approach the work.
-
-###### Recognise achievement and celebrate success
-A simple ‘thank you’ shows someone that what they have done is appreciated, and is hugely motivating. Celebrating major, and minor, achievements is an important part of our culture at dxw. It builds team spirit and morale.
-
-###### Guard our values
-Lead by example. The actions and behaviours of line managers must always demonstrate our dxw values. We should always hold ourselves accountable to our values, and encourage the same in all of our colleagues, including those we line manage.
-
-###### Continuous constructive feedback
-Find out how each of your team members prefers to receive feedback, and develop an approach which reflects that.  Ongoing positive and constructive feedback is essential if someone is to feel valued, learn from their experiences and become better at what they do.
-
-###### Be honest
-Being honest means telling the truth and being consistent in what you say and who you say it to. Telling things as they are, while being sensitive to the situation and individual, ensures that people know where they stand and will help to build mutual trust and respect.
-
-###### Wellbeing
-Line managers look out for the health and wellbeing of the team. They are responsible for carrying out dxw's duty of care to its people.
-
-#### Directors & heads-of
-
-All members of the Directors and heads-of team are here to help answer any questions you might have. Your own Director and/or Head-of profession or location is there to provide support on matters relating to dxw and your career with us, as well as profession specific questions. Similarly, they are here if you need to escalate any job-related concerns.
-
-#### Our Managing Director, Dave
-
-At dxw, all doors are open if you need to raise a concern or just have a chat - this includes our MD. Dave is always available to discuss any questions you have about the company and its future. Equally, if you feel you need to escalate anything to him, don’t hesitate to get in touch. Dave's diary is open and you can see it on Google Calendar. If you would like to schedule some time with him, please feel free to book something.
-
-### Time
-
-Our working hours are 10:00-18:00, Monday to Friday. Some people work different
-hours by arrangement. Anyone is free to do that as long as their hours of work
-don't make it hard for other people to get things done. For example, many people
-arrive earlier than 10:00 and leave earlier, which is generally fine.
-
-Each team has a short standup every morning, where we each tell the whole team about
-a single thing we will get done that day. If you think you're going to be late, you should
-let everyone know in the project Slack channel.
-
-Most developers have maintenance responsibilities, which they do during [ticket
-time](#ticket-time).
-
-We do our very best to work to a [sustainable pace](#sustainable-pace). But
-sometimes, when we're approaching a firm deadline or a launch, or a client is
-having an emergency, we work longer hours than normal. From time to time,
-there's an emergency that means we have to work during unsociable hours to solve
-the problem. Neither of these happen very often, but they are a normal part of
-life at dxw.
-
-Sending emails or posting in Slack outside of working hours can be a good way to get things off your mind,
-but it can create an unintended sense of urgency for the people who receive your message. Try to avoid creating
-that urgency when it’s not necessary. For example, by specifically saying that you don’t expect an immediate response.
-
-Unless they are actually urgent, you can ignore messages you receive
-outside of working hours and handle them when you are back at work.
-
-### Flexible working
-
-Our policy is informed by the way we work and the way we charge clients for our time.
-
-### How we work
-
-#### Monday to Thursday
-
-**Client facing**: We charge clients “time and materials” for the work we do, based on a [per person day rate](https://assets.digitalmarketplace.service.gov.uk/g-cloud-10/documents/92768/432689933684667-sfia-rate-card-2018-05-23-1413.pdf). We generally schedule team members to work on particular projects for a whole sprint at a time, and track and bill that time in half days and whole days. Delivery leads work with the finance team to track and invoice the time of the team; having regularly patterned working helps the process to run as smoothly as possible, without confusion and without taking more time than needed. Any working arrangement needs to make it straightforward to track, report and invoice for your time.
-
-When working on a project we work as a single multi-disciplinary team. We’re often working on phases of projects where there’s a lot of unknowns and a lot of learning, so we use agile approaches and strongly favour being able to work together on problems. That’s often easier when co-located, particularly when working with clients, pairing, or participating in workshops. Any working arrangement needs to support active synchronous collaboration with the team.
-
-**Internal facing**: Internal facing roles, in which time is not billable to a client, have a more regularly structured five day working week. Everybody is encouraged to take part in Friday work, at least occasionally.
-
-#### dxw days
-
-We regularly come back together as a team to work on our own projects and processes, normally each Friday. These dxw days are important for us to maintain our strong culture and identity, separate from the clients we work for. Our sprints start on a Wednesday and end on the Tuesday two weeks later.
-
-### How you can work
-
-#### Overall requirements
-
-**Client facing**: Any working arrangement needs to allow you to participate in most Fridays and be around for the important start-of- and end-of-sprint ceremonies.
-
-**Internal facing**: Working arrangements for these roles are slightly more flexible as the delivery needs listed above are not relevant.
-
-#### Part time working
-
-The normal working pattern is 5 days per week, Monday–Friday.
-
-**Client facing**: We’re happy to talk about a 4-day week, on the basis of a fortnightly pattern to accommodate our Monday–Thursday billing week and attending some Fridays. It may be possible for some roles to work a 3 day week due to the nature of the role potentially not being full-time on a single project, this would be dependent on a number of contextual factors and discussion with the team. We’re unable to support a 3-day (or fewer) week for all other roles due to the overheads for scheduling.
-
-**Internal facing**: We’re happy to talk about part time working for any number of days, dependent on the role.
-
-Part time hours spread over 5 days, e.g. working 21 hours across a full week, or roughly 4 hours a day, may be possible for internal facing roles after discussion, but is likely a no for client facing roles.
-
-Salary and holiday allowances (including bank holidays) will be prorated for part time roles.
-
-For example, when working a 4 day week, the pro rata leave allowance will be 20 days per year of annual leave and 6.5 bank holiday days, giving a total leave allowance of 26.5 days. Bank holidays that don’t fall on a non-working day must be booked as annual leave.
-
-#### Core and non-core hours
-
-Everybody is expected to work seven hours a day. Normal office hours are 10am–6pm.
-
-If you’d prefer to start a little earlier and finish a little earlier (say 9am–5pm), this is definitely OK and can happen without any formal discussion for all roles.
-
-If you’d prefer your working hours to start after 10am or finish before 5pm (still keeping to seven hours), we’re happy to discuss this and either **might** be possible. The impact of this would be less for internal facing roles than for client facing roles, but both would require a discussion.
-
-Salary and holiday allowances would remain the same.
-
-#### Compressed hours
-
-Compressed hours involves working your full hours in fewer days. For example: 35 hours in 4 days, 9.30am–6.45pm.
-
-We don't offer compressed hours for client-facing roles due to the complications for the way we bill our time and present our services to clients.
-
-We are happy to have a discussion about compressed hours for internal-facing roles but cannot guarantee this would be an option.
-
-35 hours in 3 days, for example, is a no across all roles. It goes against our encouragement of [sustainable pace](#sustainable-pace).
-
-For working patterns with the same number of hours each day, holiday allowance can be treated the same as for [part-time roles](#part-time-working). For working patterns with varied hours, the annual allowance for both holiday and bank holidays should be counted in hours (231 hours per year) and bank holidays that fall on working days must be booked as leave.
-
-#### Remote working/location
-
-Generally, we work either at our office or at client sites.
-
-We’re happy to support working from home from a logistical or well-being related perspective. While we don’t support fully-remote roles (legacy arrangements being the exception), we can look at anything from 1–3 days per week following a discussion.
-
-If you need to work from home for a one-off thing then that doesn’t require contractual arrangement – just talk about it with your team before the day, make sure you note it in your calendar and include it in your standup note that day.
-
-#### Requesting a change of working arrangement
-
-If you would like to discuss a change to the standard working pattern, you can either speak to your Head-of directly, or, contact the People Team to facilitate and support this conversation by phone, email, slack or in one of our bi-weekly HR surgeries. In this initial conversation, we will discuss your request, look at the impact on the team and your work, agree the best time for this arrangement to begin and how it will be communicated to those necessary.
-
-If you have an alternative working arrangement, you should make sure it’s reflected in your calendar so the rest of the team can be confident in knowing when you are and aren’t around.
-
-#### TOIL
-
-Where possible we try to keep a sustainable pace of work and avoid working outside normal hours; occasionally this might not be possible.
-
-##### How is TOIL calculated?
-
-TOIL (time off in lieu) is awarded when you work over and above your contracted working hours continuously for a period of time or when you attend/travel to an event outside of your contracted working hours. TOIL should be agreed with your delivery lead or line manager ahead of doing the extra work.
-
-We encourage you to use your TOIL within the two weeks of extra work or event attended as it's meant to be for resting and making up for working  at a sustainable pace.  We know this may not be feasible in every case so please speak to your Line Manager or a member of the HR team if you have any questions.
-
-There are two options of how to use your TOIL, you can calculate the amount of hours you have accrued (ie half a day) and take it off at once or take a couple of hours a day spread over a period of time. Planning when you’ll take TOIL is important, particularly if you’re working on a billable project so please speak to your Delivery Lead before doing any overtime and arrange when you’ll be able to take the time back.
-
-##### How to request TOIL?
-
-Using BreatheHR similar to the way that you request holiday there is a TOIL drop down, please write a note as to why you are requesting the leave and this will be approved by a member of the HR team. Please note this will not deduct from your holiday allowance shown on your BreatheHR dashboard.
-
-### Remuneration
-
-dxw will institute a cost of living raise each year on 1st April. The percentage
-will be set by the [CPI Index](https://www.ons.gov.uk/economy/inflationandpriceindices)
-as of 1st April each year.
-
-* If you have passed your probation, you will receive your raise in the April payroll.
-* For those team members who joined prior to 1st April of that year, but haven't yet
-  passed probation, you will receive your raise in the month you successfully complete it
-  and it will be the same percentage as of 1st April CPI that year.
-* If you joined on or after 1st April (that year), you will not be eligible for a cost
-  of living raise until the following April.
-* If you are leaving during April you will not receive the cost of living raise.
-
-### Holiday
-
-If you want to take time off:
-
-1. Discuss the dates with your team and delivery lead
-
-   This gives them a chance to manage any impact it might have on the wider team and the project.
-
-1. Request the holiday through BreatheHR
-
-   We use BreatheHR to track who's off and when, so we can plan for it. Your line manager can then see and approve your request.
-
-1. Add your holiday to your Google calendar
-
-   If someone is trying to find out where you are, or when you're available, the first thing they'll check is your calendar.
-
-   When you are on a client project, you may also need to add your holiday to a shared or team calendar. Check with your delivery lead.
-
-Your line manager will normally approve requests that are for 10 days or less and made at least 4 weeks in advance. Anything longer or requested with less notice will need to be managed to understand its impact on client, team or personal work.
-
-There is more information about dxw's holiday arrangements in your contract of employment.
-
-### Sickness
-
-If you are sick, you must let us know by 10:00, or as soon as is reasonably
-practical. Do not come to the office. If you come to the office when sick, you
-may be sent home again.
-
-If you're sick but able to work, you can work from home. Everyone at dxw should
-have a laptop, and should generally take it home with them in case it's needed.
-If you're sick and at home but don't have your laptop, it can be couriered to
-you.
-
-When you return to work, you must check that your sickness has been correctly
-recorded in BreatheHR, and update it if necessary. If you're sick for more than
-a week, you'll also need to provide a [fit
-note](https://www.gov.uk/government/publications/the-fit-note-a-guide-for-patients-and-employees).
-
-If you're sick on more than 10 occasions or for more than 10 days over a
-12-month period, we'll invite you to an absence meeting to discuss your
-situation. We may agree with you an action plan and/or a review period. We may
-seek medical advice. Should your attendance fail to improve after a three-month
-period, we will invite you to a further absence meeting to discuss your
-situation. In this meeting we will also give consideration to your possible
-dismissal.
-
-We'll also invite you to an absence meeting if you're off sick for more than
-three weeks on a single occasion. In addition to the above, we will seek to
-support your return to work and discuss with you any temporary or permanent
-adjustments which may assist you. If you are unable to return to work in your
-current role we will consider if there is a suitable alternative role. If we are
-unable to reach an agreement that will permit you to return to work, we will
-give consideration to your possible dismissal.
-
-We will always only consider dismissal after we have exhausted all other
-reasonable options.
-
-### Compassionate leave
-
-If you need to take compassionate leave, let your line manager and a member of the HR team know, so we can support you in the right way. If you are on a project, we can then work with your delivery lead to manage the impact on the team.
-
-To record the compassionate leave in BreatheHR, choose Other as the Type of Leave, and choose Compassionate as the Reason.
-
-### Parental leave
-
-While many terms around parental leave are gendered, gender is not a factor in what
-leave you are entitled to. What matters is whether or not you are pregnant.
-
-#### If you're pregnant
-
-If you're pregnant, you’ll probably be entitled to [Statutory Maternity Leave (SML)
-and Statutory Maternity Pay (SMP)](https://www.gov.uk/maternity-pay-leave/leave),
-which is funded by the government. They will pay you 90% of your normal salary
-for the first six weeks of your leave.
-
-Assuming you are entitled to SMP (almost everyone is), dxw will also pay you 90%
-of your salary for the second six weeks of your leave. This contribution
-is called Occupational Maternity Pay (OMP). Taken together, this means that
-you’ll have twelve weeks of leave on 90% of your normal salary.
-
-To be eligible for OMP, on returning to work you will need to stay at dxw for at
-least three months full time (or proportionately longer if working part-time).
-If you decide not to, you will have to repay any OMP you received.
-
-When you know you are pregnant please do tell us as soon as possible, so we can
-check that your working arrangements are safe for you and also ensure you are
-paid for time off for antenatal appointments.
-
-#### If you're not pregnant
-
-If your partner is pregnant, you are adopting, or you are having a baby
-through surrogacy, you’ll probably be eligible for [Statutory Paternity Leave (SPL)
-and Statutory Paternity Pay (SPP)](https://www.gov.uk/paternity-pay-leave). SPL
-may be taken for one or two consecutive weeks, between the date of birth and 56
-days afterwards. SPP is £145.18 per week.
-
-If you qualify for SPL and SPP, dxw will instead pay you your normal salary for
-three weeks of paternity leave. If you want to take more than three weeks of
-leave you can use [shared parental leave](#shared-parental-leave).
-
-#### Shared parental leave
-
-If you're having a baby, adopting a child, or having a baby
-through surrogacy, you may be eligible for [Shared Parental Leave and
-Pay](https://www.gov.uk/shared-parental-leave-and-pay). If you're interested in
-taking this up, please talk to the People Manager.
-
-#### Keep in touch (KIT) days
-
-You have 10 paid KIT days to take during your parental leave if you wish to come in
-for departmental meetings, events or just to spend some time in the office.
-
-Any bank holidays that you miss while on parental leave will be added to your
-holiday entitlement when you return to work.
-
-### Working from home
-
-Generally, we work either at our office or at client sites. But it's usually
-fine to work from home from time to time, or in order to complete a specific
-task. If you're working apart from your team, it is essential that you remain
-contactable and productive, and the onus is on you to be especially
-communicative.
-
-If you are working from home, you must record this as an absence in BreatheHR.
-There is a category, "WFH", for this purpose.
-
-### Data protection
-
-Though dxw doesn't control much personal data, our clients generally do. And
-some of it may be held on sites that we host. Everyone at dxw has a
-responsibility to keep that data safe, and process it in accordance with the [data
-protection
-principles](https://www.gov.uk/data-protection/the-data-protection-act).
-
-In particular, we:
-
-* Only process personal data as part of work on the service that we're
-  contracted to provide to a client
-* Don't access personal data unless we need to in order to do our jobs: don't
-  read people's personal data or private communications without good reason
-* We do not ever disclose people's personal data to anyone outside dxw unless
-  specifically instructed, and are satisfied that it is legal to do so
-
-If you have any questions about data protection, talk to Harry.
-
-### Your details
-
-Please tell us promptly if your name, address, telephone number or next of kin
-details change.
-
-### Disciplinary procedure
-
-If you do something that we feel constitutes misconduct, or your performance in
-your job has been poor, we'll talk to you about it. Hopefully, there's just been
-some misunderstanding, or some problem that's easy to solve and won't recur.
-Formal action will not be taken without careful investigation of the facts.
-
-If we feel it's appropriate, we may verbally warn you, explaining what has been
-unacceptable and what you need to do to improve your conduct or performance.
-
-If your conduct or performance fails to improve following a verbal warning, or
-if the matter is serious enough that a verbal warning is not appropriate, we may
-hold a disciplinary meeting at which you may be accompanied or represented by a
-colleague or trade union official. Following this meeting, we may:
-
-* Conclude that no misconduct has taken place, or that there is no poor performance
-* Issue you with a written warning, which will explain:
-  * The nature of the misconduct or poor performance
-  * The change to your behaviour or performance that you need to make
-  * The time within which the change needs to be made
-  * The consequences of not making the change (for example, dismissal)
-* In cases of gross misconduct, dismiss you without notice
-
-If you disagree with the outcome of this hearing, you may appeal against the
-decision. You must do this in writing. If you do so, your appeal and the
-circumstances of your case will be reviewed by a member of staff who has not
-been involved in your case before. That member of staff and the Managing
-Director will then meet to discuss your case, and will either uphold the outcome
-or schedule another disciplinary meeting. dxw's decision following that meeting
-will be final.
-
-### Grievances
-
-If you have a grievance about your employment or a complaint about another
-member of staff, talk to the Managing Director as soon as possible.
-
-The first step is to discuss the problem to see if it can be quickly resolved.
-
-If this discussion does not satisfactorily resolve the problem, you should put
-details of your grievance in writing and send it to the Managing Director. They
-will arrange a meeting to discuss the matter, at which you may be accompanied by
-a colleague or trade union official. Following this discussion the Managing
-Director will provide a written response.
-
-If you disagree with this response or the matter remains unresolved, you may
-appeal by respond in writing. A further meeting will be arranged and the
-Managing Director will again respond in writing. This decision will be final.
-
-### Use of personal devices at work
-
-Most of us use at least one personal device as part of our work, because it's
-more convenient than carrying lots of devices around. However, no one is
-obligated to use a personal device for work. If you need a dxw-provided phone,
-tablet or other device, please ask for one.
-
-Anyone who does use a personal device must take reasonable care to ensure that
-it cannot compromise dxw's security. This includes implementing prudent security
-measures, being mindful that your personal devices could be targeted as part of
-an attack on dxw or its clients. For example, you might receive an email to your
-personal email address designed to trick you into revealing a work-related
-password.
-
-Exactly what security measures are prudent may vary depending on the device and
-what you're using it for. Some good practice examples are:
-
-* Configuring screens to lock after a period of inactivity
-* Ensuring that
-  work-related data on the device is regularly backed up
-* Encrypting storage
-* Using good passwords and changing defaults
-* Avoiding connecting devices to untrustworthy networks (internet cafes,
-  security conferences, unencrypted (open) wifi networks, etc)
-* Disposing of your device securely when you no longer need it
-
-If you need to use a personal device but cannot take these sorts of measures,
-you should get permission first.
-
-### Report a lost or stolen device used for work
-
-* Submit an urgent ticket by sending an email to support-emergency@dxw.com
-  stating which work device was lost or stolen and when the incident had occurred
-* Our support staff will be immediately notified, at any time of day
-
-### Expenses
-
-From time to time, some of us spend our own money at work. Most often, this is
-things like:
-
-* Train fares for unexpected travel
-* Refreshments purchased for meetings with clients
-* Stationery/materials, especially for workshops or events
-
-dxw will always pay expenses which are:
-
-* __Necessary__: We only expense things we need in order to be able to complete
-  our work
-* __Proportionate__: The total expense should be proportionate to the
-  work at hand. In general, we try to avoid spending lots of money. For example,
-  unless you have a good reason, don't get a cab to a meeting when you could get
-  a train.
-
-Wherever possible, it's best to check that expenses can be reclaimed before
-incurring them.
-
-We manage expenses using Xero. For more information about how to do this, see
-the [guide on claiming expenses](/guides/claiming-expenses)
-
-### Reporting our time
-
-Everyone who works on a client project at dxw is responsible for reporting the time they spend on projects. We usually work with our clients on a [time and materials basis](https://www.gov.uk/guidance/how-to-pay-for-digital-outcomes-and-specialists-services#time-and-materials), so it’s important we can accurately track and report how our time is spent on client projects.
-
-We use [10,000ft](https://app.10000ft.com/) to schedule our work, which helps us to forecast our capacity over future weeks and months in a reliable way.
-
-When your planned leave has been approved, update the schedule in 10,000ft to reflect this. This helps us to look ahead and is recorded as “Out of office". Each member of our delivery team uses the tool to record the days they work on client projects on a weekly basis.
-
-We track our time at the same level of granularity that we bill it – for almost everyone in the team, that’s half days or whole days.
-
-#### What to do when reporting your time
-
-When reporting our time, we follow these guidelines:
-
-* If what was scheduled matches reality, simply confirm this time.
-* If you worked on a named project (client or internal including "dxw Support"), that differs from the schedule, record your time as that.
-* If you worked on something else, leave the time blank or zero out what you were scheduled to work on.
-* If you were away on planned leave, confirm your time as "Out of office".
-* If you were off sick, record your time as "Sick".
-* If you had unplanned leave, record your time as "Out of office".
-* If you were away due to a regular day off, as part of your working pattern, leave the time blank or zero out what you were scheduled to work on.
-
-If you’re not doing client work, then unless you’re working on one of a handful of named internal projects or support, you don’t need to record your time against any other piece of work – the assumption is you’re doing valuable work, whether it’s learning, helping with recruitment or improving our tooling and processes, and we don’t need itemised time tracking to justify that.
-
-We’ve set up the platform, so that it understands individual team members’ working patterns. This means the team don’t need to worry about entering in their non working days.
-
-Our delivery leads lend a helping hand when delivery team members aren’t sure how to record their time – they’ve been doing this for a long while and have a well developed sense for it.
-
-### The buddy system
-
-The buddy system is the main way we help each other to perform well and improve
-our skills. During your first couple of months at dxw, as you get to know the
-team, you should choose someone and ask them to be your buddy.
-
-As soon as you have a buddy, you'll meet regularly with them to talk about how
-you're doing. You can talk about things you'd like to improve, problems you're
-having or new things you'd like to do. After you've discussed what you want to
-achieve, you'll decide together how best to go about it. In your regular
-meetings, you'll talk about what's working well and what's not, and decide if
-you need to change something.
-
-During each meeting, we add cards to the [buddy
-trello](https://trello.com/b/TmiYBPZg/buddy-chats), so that the rest of the team
-know what you're working on and can help. If you want to talk about something
-private, you can. You don't have to put everything on the board. But the
-presumption is that we do, unless there's a good reason not to.
-
-The buddy system is there to help us all improve, to make sure we're doing the
-right kind of work and to check that we're dealing with practical problems we're
-facing. It's not line management, so it's not the right place to talk about
-holiday, salary, sickness, absence or anything disciplinary. If you need to talk
-about those things, talk to the People Manager.
-
-There are two main ideas that underpin this system.
-
-#### We are each responsible for our own improvement
-
-Before this system, we had regular performance reviews. They were supposed to be
-quarterly but generally ended up being annual. They didn't work very well, and
-were very top-down. We don't think this is the right way.
-
-We prefer to assume that everyone wants to improve, and will do so given the
-time and space to work on it. The buddy system is there to provide a set of
-prompts to ensure that this happens, and an explicit time to talk about it.
-
-#### It's best to be open
-
-Trying to improve things in secret is a missed opportunity to get help from
-others. We may each be responsible for our own improvement, but we're also a
-team: we should help each other. Recording the things we're working on with the
-buddy Trello is an unintrusive, quick way to ensure that everyone else knows
-too.
-
-### Calendars and documents
-
-We use Google Apps for Work to manage calendars, write and share documents.
-There is a dxw folder where we share most of the things we write. If you can't
-see it when you log in to Google Drive, you'll need to ask someone else to send
-you the link, and then click "Add to drive".
-
-When we write new things, we try to save them in a sensible folder within the
-existing structure.
-
-### Protective marking scheme
-
-Some information that we have is confidential. We use a protective marking
-scheme so that everyone understands how to handle this material, and who they're
-allowed to disclose it to. All of the documents and data we hold will fall into
-one of the categories below.
-
-* __Management-in-Confidence__: internal documents whose circulation within dxw
-  needs to be restricted.
-* __Company Confidential__: information owned by dxw
-  which would be of value to those outside the company, such as competitors, and
-  whose loss or theft would potentially damage the company.
-* __Client Confidential__ or __Commercial in Confidence__: information owned by
-  dxw or its clients, which needs to remain confidential between dxw and the
-  client.
-* __Unclassified__: information, which would not be of significant commercial
-  value to those outside dxw.
-
-Some of our clients also have protective marking schemes. For example, all
-central government bodies will apply the [Government Protective Marking System
-(GPMS)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/251480/Government-Security-Classifications-April-2014.pdf).
-If you are in possession of materials that are protectively marked using other
-schemes, treat them as company confidential.
-
-We take care to handle all data carefully, but when information is protectively
-marked, extra requirements apply.
-
-Because we value openness highly, we take care not to over-classify information.
-We don't protectively mark information unless there is a good reason to keep it
-confidential.
-
-#### Management-in-confidence
-
-This category is used only for dxw's most confidential information. For example,
-employment records, salary details and company strategy documents.
-
-Do not share any information with this marking with any person, whether internal
-or external to dxw.
-
-This information:
-
-* Must be clearly labelled or described as "Management-in-confidence"
-* When printed
-  * Stored only in a locked container
-  * Transported only via courier, recorded delivery or personally by dxw staff
-  * Destroyed by cross-cut shredding when no longer required
-* When digital
-  * Stored in an encrypted format
-  * Communicated only when encrypted or via an encrypted connection, unless emailed from one dxw.com address to another
-
-#### Company Confidential
-
-This category is used for information which should not be communicated outside
-dxw. For example, details about how we operate security controls or internal
-discussions about client work.
-
-Exactly the same controls apply to this information as detailed under
-Management-in-confidence, with the exception that Company Confidential
-information can be shared within dxw as required.
-
-#### Client Confidential or Commercial in Confidence
-
-This category is used for information which is disclosed to a limited group of
-people external to dxw, or which is unclassified information we have received
-from clients. For example, dxw proposals, presentations for pitches or planning
-documents.
-
-Unless otherwise specified, all unclassified information we receive from clients
-falls into this category.
-
-This information:
-
-* Must be clearly labelled or described as "Client Confidential" or "Commercial in Confidence"
-* When printed:
-  * Stored out of sight
-  * Destroyed by cross-cut shredding when no longer required
-* When digital:
-  * Stored in an encrypted format when on exchangeable media or a mobile device
-
-As a rule of thumb, label a document as Client Confidential if it mostly
-contains the client's confidential information, or Commercial in Confidence if
-it mostly contains dxw's.
-
-#### Unclassified
-
-Anything not captured by the sections above is unclassified. Examples are
-external marketing material, general emails and letters.
-
-Beyond a general duty to treat information carefully, unclassified information
-is not subject to any specific restrictions.
-
-### Email Signature
-
-Name<br>
-Job Title<br>
-name@dxw.com<br>
-Twitter handle - if you’re comfortable to share<br>
-Mobile - if you’re comfortable to share<br>
-
-www.dxw.com :: 0345 2577520 :: @dxw :: creating better digital public services
-
-### Email Autoresponder
-
-If you require an out of office message on your email account please send
-your request to support@dxw.com with the subject title **Email Autoresponder**
-which must include start date, the contact details for another member of the
-team for any urgent queries, and return date to be added to our mail server.
-
-### Internal Tech Support
-
-If you experience problems with the office printers, wi-fi, video conference
-set-up, Macs etc… You may send a message in the **#dxw-techsupport**
-Slack channel.
-
-**Note:** please use Helvetica or Arial as the font in your emails.
-
-### Benefits
-
-All perks and benefits are available to the dxw team after the successful passing of their probationary period.
-
-#### Pensions
-
-dxw provides a pension which is operated by Aviva. Once you have passed your 3
-month check in, you will be auto enrolled into the scheme, receive details by
-post of the necessary employer/employee contributions and have the option to set
-your percentage or opt out.
-
-dxw will match any contribution up to 5%.
-
-Your contribution will be relief at source, with 0.8 deducted from your monthly
-salary and the additional 0.2 added from tax relief.
-
-For more details on Relief at Source, please visit the [Aviva website](
-https://www.aviva.co.uk/retirement/news-views/report/making-sense-of-tax-relief-on-pension-payments/).
-
-#### Childcare Vouchers
-
-The Government closed the Childcare Vouchers scheme to new entrants on 4th October 2018. This means we are no longer able to add new members to the voucher scheme with Busy Bees.
-
-The government has introduced new ways to help parents with childcare costs which you access directly: [https://www.gov.uk/get-tax-free-childcare](https://www.gov.uk/get-tax-free-childcare)
-
-For more information, please speak to the People Manager.
-
-#### Personal learning and development allowance
-
-We have an annual allowance of £750 and up to 4 days per person, to be used for a range of professional and personal development activities like workshops, short courses or conferences.
-dxw pays for the event ticket, travel, and accommodation, but you will need to cover your own costs for food, drink and supplementary equipment.
-
-You should discuss your training plan with your line manager, they will help you identify potential areas for development and support you to find suitable events or training.
-
-You may also use the allowance to attend a non role based conference or event focused on improving your health and wellbeing. You will receive two days off for this, and can top up the time from your annual leave allowance.
-
-Attending conferences and events that are not related to your role, is a taxable benefit. As your employer, we will make the declaration, HMRC will then adjust your tax code accordingly to collect the tax via PAYE.
-
-##### How it works
-
-The allowance will be available to everyone once they have completed their probation period, within the dxw financial year which runs from the start of July to end June. It will be pro-rata for staff who work part-time. If you don’t spend your allowance within the financial year, it cannot be carried over.  We will start afresh each year, as part of our annual budgeting cycle. Your allowance is counted as being spent at the time of purchase rather than at time of use; for example, if you buy a conference ticket in May for an event in July the same year, the deduction will be made to the budget for the financial year that May falls within.
-
-Any events (paid, free, speaking, etc) you attend should be logged in BreatheHR as a training request. If they do require payment, please include weblinks and an estimate of the ticket, accommodation and travel costs (up to the maximum of £750, though you are welcome to pay the difference for more expensive events). This helps manage the annual budget and will give you a great view of what you have attended in the year.
-
-It’s ok for members of the team to go together, but we need to ensure that training days have the lowest impact on client work, so there may be times we need to consider whether your request is possible. Our Director of Delivery will help with prioritisation in those circumstances.
-
-We know that lots of training isn’t paid for, and involves things like coaching and mentoring, learning from colleagues, being an active part of networks, and other self-directed learning. We will encourage and support people who want to use unbilled days for different types of professional development.
-
-If appropriate, it’d be great if you would talk about your experiences in a blog post or bikeshed - sharing good events and useful training will give others the opportunity to attend.
-
-At the end of each financial year we will review our financial position with the intention of increasing the annual allowance.
-
-If you have any questions, please contact the HR team.
-
-#### Cycle to work scheme
-
-dxw operates a cycle-to-work scheme, which may allow you to purchase a bicycle
-at reduced cost. If you would like to take this up, please register
-[on the cycle scheme website](https://www.cyclescheme.co.uk/18eb71)
-
-#### Eyecare vouchers
-
-dxw provides eyecare for the team via a voucher system run by ASE Corporate Eyecare Ltd and Boots.
-
-Details of what the wellbeing voucher offers can be found here: [Eyecare for Wellbeing](https://www.eyecareplans.co.uk/corporate-eyecare/eyecare-for-wellbeing/).
-
-[Apply for a wellbeing eyecare voucher](https://gw.eyecareplans.co.uk/dxwe12q2415d3df)
-
-#### Book purchase
-
-If there is a book relevant to your work that you would like to read, make a request through the #dxw-purchasing slack channel and the Bus Ops team will buy it for the library.
-
-#### Equipment
-
-dxw will pay for the equipment needed to enable you to work comfortably and safely. dxw also offers a budget of £25 towards a work backpack. Use the `dxw-purchasing` Slack channel to request any equipment you need, or talk to anyone in business operations if you are unsure if a purchase will be covered.
 
 ## Sharing
 


### PR DESCRIPTION
Moved the internal focussed content into a Working here section with Managing your day to day work, Your pay, pension and other benefits, Supporting your development and wellbeing, and Hiring new people.
In future we can move the subsections into separate pages, and move more details material into guides where we can go into more detail.
For reviewers, my main concern is to check whether I've accidentally deleted anything.