### PR TITLE
Create a The work we do section

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -168,11 +168,134 @@ regularly assessing the impact of all our policies and practices.
 
 Thank you for being you - it makes us better.
 
-## Building services
+## The work we do
 
-### Client experience
+### Sales
 
-#### Responsiveness
+#### Typical projects
+
+Most of our projects are to  research, design , build and support  digital services for the public sector and organisations focused on work for ‘public good’. Broadly speaking, they are usually transactional services ([making payments, bookings, reporting things](https://www.youtube.com/watch?v=NN5B9rL_Hxs) or informational services ([corporate websites](https://www.judiciary.uk/), [campaigns](https://firekills.campaign.gov.uk), intranets) . Sometimes they're a bit of both.
+
+In so doing, we try to make sure that the organisations we're working with will be able to operate their new services well and sustainably. This sometimes involves work that an agency might not normally do, like advising an organisation's leaders on how their teams could be restructured, or on what their digital strategy could be.
+
+With the development of dxw digital’s strategy team, we are increasingly  targeting more strategy-shaped opportunities, to help our clients prepare for, or improve the delivery of digital projects.
+
+We also help clients host some of the services that we build, and by selling subscription-based products that are related to the rest of our work.
+
+#### Opportunities
+
+We bid on opportunities through a range of channels.
+
+Some  of our opportunities  arrive directly, often via email, as a result of recommendations, word-of-mouth or through our active engagement and networking in the digital and public sector community.
+
+We also take on work that is received for existing services via helpdesk tickets.
+
+Most of the larger opportunities we bid on  arrive via more formal channels like public sector framework agreements such as the Digital Marketplace.
+
+When any opportunity arrives, we record it in our CRM tool, Hubspot.  This happens automatically for  opportunities published on the Digital Marketplace Outcomes and Specialists framework. Other opportunities are entered individually into Hubspot if they arrive to a specific person.
+
+We record as much information as we can about opportunities when they arrive. An opportunity should be described in enough detail that someone else in the team could pick it up and work on it if needs be. That means that we always record a sensible name, the details of the organisation and where possible, we associate the opportunity to the Hubspot contact and company record of the person we're talking to. If they have provided any documents, we upload those into Hubspot as well.
+
+Opportunities go through several stages during their life, to show whether we're waiting for more information, waiting for a meeting, writing a proposal and so on. For opportunities that we’re bidding on via the Digital Marketplace, our process mirrors the timelines buyers publish in alignment with these standard procurement rules.
+
+When the process ends, a lead will either be [won](#winning-work) or [lost](#losing-work).
+
+#### Screening potential projects
+
+At dxw our mission is to help create public services that improve people’s lives. Whether we achieve this depends a lot on the work we choose to do.
+We encourage an open and honest discussion about which work we take on. And we actively seek different perspectives, both inside and outside of dxw.
+
+To decide whether a potential project is ethical and supports our mission, we consider:
+* **Value**
+
+  The work is beneficial to the public, the client and dxw.
+
+* **Practicality**
+
+  We can produce a great result within the likely constraints.
+
+* **Culture**
+
+  We can work together with the client, the users and other stakeholders in ways that support our [values](#values) and [principles](#principles).
+
+#### Matching people to projects
+
+We understand that members of staff may have ethical, religious or other concerns about working on a particular project.
+If you do have concerns about a project, please raise them with your line manager or head of profession.
+
+#### Budgets
+
+Clients aren’t always able to talk about their budgets, but [we do need to know](https://medium.com/@monteiro/why-i-need-to-know-your-budget-a61ec864c898). If they absolutely can't tell us, we do our best to estimate at what it probably is, based on the information we have.
+
+Where we don't think we could do what the client needs within their budget, we explore alternative options with them that are more affordable. Sometimes this works out, sometimes not. That's ok. Where it does, it tends to be because we've made a good case that it's better to have a small feature set that works really well than a large one that's slightly disappointing.
+
+Where clients have a larger budget than we think they need, we say that too. This usually means explaining why we're able to do the work for less than they thought. We also think about what extra things we could do to improve their chances of success and suggest extra work they could do.
+
+Where a budget is disclosed that's more than we think is necessary, we usually propose a piece of work that uses that budget fully. But we're always open, and tell them that we've done this, and that we'd be delivering more than the minimum. And we're always happy to win a smaller bit of work than the client thought they'd need. We try to structure these proposals so that the extra work is easy to remove.
+
+#### Sales meetings
+
+Wherever possible, we meet prospective clients before writing a proposal. This is because face-to-face conversation is the most efficient way to communicate, and the projects we bid for are often complex. Sometimes, this meeting is the way we qualify an opportunity.
+
+By the end of this meeting, we should make sure that we understand:
+
+* Who the client's users are
+* The user needs the client is trying to meet
+* Their current vision for how those needs will be met
+* Any notable technical requirements
+* What the project's budget and deadlines are
+* How many suppliers are likely to be bidding
+* When they need to receive our proposal by
+
+This meeting usually involves quite a bit of discussion about the project. In
+those discussions, we speak freely and openly, offering advice where appropriate
+and making any suggestions we might have. We always try to be as [helpful](#helpful),
+[positive](#positive) and [creative](#creative) as we can.
+
+It's important that we use this meeting to find out the information that we need
+to write a good proposal. But it's just as important to prove our expertise, to
+deliver value early and to leave the client with a positive first impression.
+
+#### Proposals and tenders
+
+If the project is being tendered via a fixed process (such as the Digital Marketplace, ) we'll respond by following the process  that the client requests.
+
+Bid writing is a team sport at dxw, so it’s important to involve the potential delivery team in the planning, writing and reviewing of the bid. This is important as it helps to set the team up for a successful pitch (if we need to do one) and eventual delivery if we win the work.
+
+Whilst the process tends to be similar, not all opportunities are exactly the same, for example, sometimes we’ll be provided will a form to complete, and other times we’ll have more flexibility on the format of our proposal.
+
+If we're writing a proposal following our own format, we often start from a proposal template. The main things we’ll often need to write are:
+
+* A description of the project's background. How did they get to the point they're at now?
+* A description of the client's vision. What are they trying to do?
+* An initial set of user needs. How does the client believe their service or project will make things better for these people?
+* Details of how we’ll approach the work
+* A proposed team to do the work, their roles and profiles.
+* How many sprints we estimate we will we need to deliver the work.
+* A timeline for when we expect the sprints and other work will happen.
+* A cost for the work.
+
+There are lots of examples of these proposals that anyone at dxw can read if they like.
+
+#### Winning work
+
+When we win work, we mark it as Won in Hubspot. We amend the budget, closing date and services sold if necessary. We write to the client to thank them and ask them for a convenient time to meet and talk about how and when we’ll start the work. We talk to the scheduling team and add the project's sprints and other work to our scheduling tool 10000ft, so that the team can see who's working on what. And we talk to the finance team so that invoices can be created as drafts in our finance system Xero, so we don't forget to bill them.
+
+#### Losing work
+
+We don’t always win work we bid for, particularly when it is run via a competitive tendering process, such as on the Digital Outcomes and Specialists framework.
+
+When we lose work, we mark it as Lost in Hubspot. We write to the client to thank them for their interest and ask them for any feedback they might have. We usually also say that we'd be happy to talk about any future work they might have. We record the main reason we didn't win the work in Hubspot along with the detailed feedback.
+
+We do our best to incorporate this feedback into future bids.
+
+Some opportunities, upon review with the team or following discussions with the client, turn out not to be dxw-shaped things. This could be for lots of reasons - capacity, capability, location and so on. This is okay. When this happens, we update the client as soon as we can, explaining the reasons for our decision.  We mark these opportunities as No bid in Hubspot, recording the main reason we made this decision, along with any context.
+
+### Building services
+
+#### Client experience
+
+##### Responsiveness
 
 One of the things our clients value most is responsiveness. Many will be under
 pressure to get things done quickly, and will be expected by their colleagues
@@ -197,7 +320,7 @@ get a question that's really for a delivery lead to answer, refer the client on.
 help to keep you productive, and will help the client understand who on the dxw
 team does what.
 
-#### Progress in every sprint
+##### Progress in every sprint
 
 Delivering projects in an agile way requires trust between everyone involved in
 delivery. Clients must have confidence in us for the process to work. One of the
@@ -213,7 +336,7 @@ visible to our clients as early as possible. This helps us to maintain trust,
 and gives us more opportunities to learn what works and what doesn't by
 involving users of the service in testing.
 
-#### Involvement
+##### Involvement
 
 We involve clients in every aspect of our work. Projects work best when everyone
 involved feels part of the same team. So, other than the internal retro, there's
@@ -230,7 +353,7 @@ and projects have varying needs, so this aspect of the process is flexible. But
 we always make the option of involvement available. If they want to join daily
 standups as well as participate in sprint planning, they can.
 
-### The structure of a project
+#### The structure of a project
 
 At dxw we follow the Government [Service
 Manual](https://www.gov.uk/service-manual) and our projects move through
@@ -276,7 +399,7 @@ We don't always do all these phases for every client. Often, we'll only be
 involved in a couple. But we can help with all or any of them, depending on our
 clients' needs.
 
-### Development sprints
+#### Development sprints
 
 We break down projects into two-week sprints. Throughout a project we maintain a
 product backlog, refine user stories based on what we learn and carry out
@@ -290,7 +413,7 @@ with a show and tell and retrospective. These sessions involve the whole team,
 including developers, user researchers, designers and delivery leads, as well as
 the product owner and other members of the client team.
 
-#### Communicate Progress
+##### Communicate Progress
 
 Every morning a delivery lead facilitates a standup. Standups last 5-10 minutes
 and are for the team to discuss what they're working on that day and whether
@@ -309,7 +432,7 @@ involved in the project to see what has been achieved. We work in an open and
 transparent way so encourage anyone interested in the project to attend the show
 and tell and ask questions.
 
-#### Plan
+##### Plan
 
 Sprints begin with a planning session, where the whole team (dxw and the client)
 review and prioritise the stories in the backlog. Working together, we discuss
@@ -332,7 +455,7 @@ there are any technical dependencies the client should be aware of. By the end
 of the session, the full team should be confident about the goal of the sprint
 and what is going to be worked on.
 
-#### Inspect and adapt our work
+##### Inspect and adapt our work
 
 At the end of every sprint, a delivery lead facilitates a retrospective where
 the team discuss how the sprint went. We talk about what went well, what didn't,
@@ -342,7 +465,7 @@ client team. We use retros to make sure we acknowledge and continue to do the
 things that are working well, and also commit to change anything that can be
 improved.
 
-#### Focus on user needs
+##### Focus on user needs
 
 At regular intervals the team look through the sprint backlog to re-prioritise
 and update stories, based on things we've learned during delivery and from user
@@ -354,7 +477,7 @@ We have regular user research playback sessions to ensure the whole team is
 involved in understanding user needs, feedback from user testing and what
 iterations means for the users.
 
-#### User stories
+##### User stories
 
 We document development work that needs to be completed by writing [user
 stories](https://www.gov.uk/service-manual/agile/writing-user-stories.html).
@@ -391,7 +514,7 @@ which must be true in order for the story to be considered "done".
 For more information about writing good stories, we recommend reading User
 Stories Applied by Mike Cohn. There is a copy of this book in the dxw library.
 
-#### Lifecycle of a story
+##### Lifecycle of a story
 
 <!-- TODO: This section should be an explanation of what happens to a story as
 it is worked on, focussing on "why" rather than "how" and explaining the
@@ -416,7 +539,7 @@ stage a given story is in.
   ready to deploy to production
 * **Done**: The story has been deployed to production
 
-### Managing delivery
+#### Managing delivery
 
 > "The delivery manager sets the team up for successful delivery. They remove obstacles, or blockers to progress, constantly helping the team become more self organising. They enable the work a team does rather than impose how it’s done."
 > --<cite>[Government Digital Service](https://www.gov.uk/service-manual/the-team/delivery-manager.html)</cite>
@@ -434,6 +557,183 @@ Outside of these sessions and standups, they maintain regular communication with
 the client and the delivery team to respond quickly to challenges as they arise.
 If priorities change during a sprint, the delivery lead works with the client
 to understand and plan for the impact of the change.
+
+### Hosting and supporting services
+
+#### GovPress
+
+GovPress is dxw's hosting platform which hosts the WordPress websites we build
+for the public sector.
+
+We built GovPress because our clients were frequently asking us for secure,
+scalable and highly available hosting, but didn't have enough budget to be able
+to build an appropriate hosting platform for their service. This is fair
+enough, because they shouldn't have to. We built GovPress to meet this need,
+and it is now used by most of our clients.
+
+We offer [managed hosting and support](https://www.digitalmarketplace.service.gov.uk/g-cloud/services/930612236449495) for WordPress websites, as well as [blogging](https://www.digitalmarketplace.service.gov.uk/g-cloud/services/355674790119695) and [campaigns](https://www.digitalmarketplace.service.gov.uk/g-cloud/services/691308552308120) platforms, through the G-Cloud framework, configured to our client's branding requirements, all on our GovPress hosting platform.
+
+You can read more about GovPress at
+[www.govpress.com](https://www.govpress.com).
+
+#### Tailored support
+
+We also offer support for services that aren't built in WordPress. We are able to host and support services with our [tailored support plan for cloud applications](https://www.digitalmarketplace.service.gov.uk/g-cloud/services/393702576050692), even if your service isn't hosted with us.
+
+#### Support helpdesk
+
+The dxw Technical Operations team build, manage and run GovPress, as well as provide first-line support.
+
+We use [Zendesk](https://dxw.zendesk.com) to manage support requests. Any
+incidents, requests for us to fix a problem or make a change to a site must
+come to us via Zendesk as a ticket. We use tickets to manage requests in order
+to:
+
+* Keep track of all the things we need to do, and what state they're in, for us and our clients
+* Have a record of the changes we're asked to make
+* Ensure that we only accept change requests from people who are authorised
+* Generate data about how much staff time is spent on each client's issues.
+
+If a client asks us to do something in person, on the phone or via email, we
+ask them to visit the [dxw Zendesk](https://dxw.zendesk.com/),
+and submit a ticket there. This is so that:
+
+* We can keep track of the issue from report to solution, and ensure that it's
+  assigned to the right person;
+* We don't risk misunderstanding the problem by writing it down based on a
+  verbal explanation
+* We can formally track the changes that people ask for, by documenting them in
+  tickets that we can look at later if we need to
+
+For these reasons, we do not do any work on a client website or service unless
+we are working during scheduled development time or on a relevant ticket. We think this
+is really important.
+
+##### Support rota
+
+We work on tickets by having a developer on support according to a rota. Developers are assigned to support for one week at a time and work on tickets for the whole week. If there is a ticket they need another developer to help with, this work is scheduled.
+
+#### Client experience (AKA: ticket principles)
+
+##### Be responsive
+
+Clients expect us to deal with their issues promptly. But they understand that this isn't always possible. They are generally forgiving of the fact that we're sometimes busy, and they understand that some issues are complex and require long investigations.
+
+The thing most clients value above all else is being kept informed of what is going on. The first quality of a good ticket experience is responsiveness: we keep clients informed of what we're doing, even if there hasn't been much progress.
+
+##### Stick to your commitments
+
+It's really important that we do what we say we'll do, and don't promise things we can't deliver. If we're unable to deal with a ticket in good time and leave an update saying we'll work on it tomorrow, we must meet that commitment.
+
+It is doubly bad to fail to meet a commitment and not say anything about it. Responsiveness is always the priority. So if for some reason we couldn't do what we said we'd do, we always respond to say so.
+
+##### Make a good impression
+
+In tickets as in all things, we are mindful of dxw's [values](#values).
+
+Most clients' routine contact with us is via support tickets, so it's vital that our clients' experience of the support system is a good one, and also that they have a positive experience with us personally.
+
+We are always considerate, and think about what style of response is best. For example, technical clients may appreciate short, information-dense responses, while non-technical clients might perceive that style as rude or dismissive.
+
+In general:
+
+* We are personable, friendly and helpful
+* If things look like they're going to get difficult or the client seems unhappy, we are honest and assume good faith
+* If we screw something up, we take responsibility and apologise. If the client seems very upset, we let a delivery lead know.
+* If we do become annoyed or frustrated by a ticket, we respond later or speak to a delivery lead about reassigning it.
+
+##### Don't over-deliver
+
+Of course, every client would like us to go the extra mile to solve their problem. But they also understand that to do that for them would mean bad service for another client - or that we never get to their issue, because we're too busy gold-plating the solution to someone else's.
+
+While we do everything we can to make sure the client is happy with our solution, we are also mindful of what's practical. We don't do serious bits of development work on tickets, or trial new approaches. We don't play with new tools or sink hours into interesting bugs. We set those things aside, and do them later.
+
+The main purpose of a ticket is to take some action that solves the problem, as quickly as possible. Generally speaking, we do the most time-efficient thing that we can. Of several potential solutions that solve the problem, assuming none is a bad one, we do the one which can be implemented the most quickly.
+
+#### Deciding what to work on
+
+Developers on support are free to work on whichever tickets they are assigned to and think is most important. But there are some important things to bear in mind.
+
+##### Triage
+
+We all have limited time. We try to spend it wisely. All other things being
+equal, it is better to spend half an hour solving each of four tickets than to
+spend two hours on one issue.
+
+##### Priority
+
+The priority of tickets is important, and we must be biased towards dealing with
+more urgent tickets before less urgent ones.
+
+Each ticket's priority should be reviewed regularly: whenever we update a
+ticket, we check the priority to make sure it's still right.
+
+#### Initial investigation
+
+It's important that we don't make changes unless we thoroughly understand what
+we're being asked to do, and are confident that the client understands and has
+approved of the implications of the change.
+
+##### Replicate the bug
+
+If the issue is a bug, we replicate the behaviour the client has reported before
+working on a fix. It's important that we can reliably and repeatably create the
+conditions necessary for the bug to arise before we start working on it. If we
+don't do this, we can't tell whether we've fixed the problem.
+
+##### Ensure the client has understood and approved the change
+
+When presented with a problem, clients don't always ask us to do the most
+appropriate thing to fix it. Sometimes we can think of a better solution.
+Sometimes the change the client asks for has some implication that they haven't
+considered.
+
+Our helpdesk service is advisory, so we're not afraid to suggest alternative
+approaches and ideas if we have them - including where there's a better
+solution, but [at a cost](#charging-for-ticket-work). We always give options
+when we can.
+
+#### Scope
+
+Clients can use the support service to ask for help with any aspect of the
+service we provide, including help with using the admin panel and advice on getting
+the best out of their site.
+
+But there are some limitations. Under the support service, we do not:
+
+* Add any new functionality requiring anything beyond extremely trivial
+  development. This does not generally include installing plugins: checking and
+  installing plugins is allowed
+* Alter the source code of a plugin or library maintained by a third party
+* Do things that the client can do for themselves in the WordPress
+  administration area. In this situation, help them by letting them know the
+  steps to take to achieve whatever they're trying to do.
+* Other than by prior arrangement, communicate on the client's behalf with the
+  operators of third-party services that the site uses
+* Install a plugin that fails an inspection
+* Do research to identify plugins to solve a particular
+  problem. It's fine to recommend something that we already know of, but in this
+  situation, we usually ask the client to do some searches on the WordPress
+  Directory and suggest one, which we can then check and install.
+* Fix complex problems that come up after a plugin or WordPress core update is
+  applied. Exactly what constitutes a complex problem is at our discretion. But
+  if we've spent a couple of hours on an update-related bug and it's still not fixed,
+  we're probably dealing with one.
+* From time to time, we may make an exception to these restrictions. If you
+  think that might be appropriate, ask a delivery lead. In all the
+  above cases, we can offer to quote for the required work.
+
+#### Charging for ticket work
+
+If you decide that a ticket asks for work to be done which falls outside this
+scope, then the work is chargeable. In this situation, we reassign the ticket to
+a delivery lead or someone from the client services team with an explanation.
+
+It is good to try to think of alternative approaches that we could do under our
+support service before taking this step - seek advice if you're unsure.
+
+The person you assign the ticket to will then treat it as a
+[lead](#leads), and contact the client to make a plan.
 
 ## Professions
 
@@ -979,304 +1279,6 @@ An hour or so, at least once every two weeks, is a good standard to aim for. If 
 #### Additional resources
 
 Here’s a great article on [7 ways to prepare for an effective one-on-one meeting with your manager.](https://knowyourteam.com/blog/2018/01/03/7-ways-to-prepare-for-an-effective-one-on-one-meeting-with-your-manager/)
-
-## Hosting and supporting services
-
-### GovPress
-
-GovPress is dxw's hosting platform which hosts the WordPress websites we build
-for the public sector.
-
-We built GovPress because our clients were frequently asking us for secure,
-scalable and highly available hosting, but didn't have enough budget to be able
-to build an appropriate hosting platform for their service. This is fair
-enough, because they shouldn't have to. We built GovPress to meet this need,
-and it is now used by most of our clients.
-
-We offer [managed hosting and support](https://www.digitalmarketplace.service.gov.uk/g-cloud/services/930612236449495) for WordPress websites, as well as [blogging](https://www.digitalmarketplace.service.gov.uk/g-cloud/services/355674790119695) and [campaigns](https://www.digitalmarketplace.service.gov.uk/g-cloud/services/691308552308120) platforms, through the G-Cloud framework, configured to our client's branding requirements, all on our GovPress hosting platform.
-
-You can read more about GovPress at
-[www.govpress.com](https://www.govpress.com).
-
-### Tailored support
-
-We also offer support for services that aren't built in WordPress. We are able to host and support services with our [tailored support plan for cloud applications](https://www.digitalmarketplace.service.gov.uk/g-cloud/services/393702576050692), even if your service isn't hosted with us.
-
-### Support helpdesk
-
-The dxw Technical Operations team build, manage and run GovPress, as well as provide first-line support.
-
-We use [Zendesk](https://dxw.zendesk.com) to manage support requests. Any
-incidents, requests for us to fix a problem or make a change to a site must
-come to us via Zendesk as a ticket. We use tickets to manage requests in order
-to:
-
-* Keep track of all the things we need to do, and what state they're in, for us and our clients
-* Have a record of the changes we're asked to make
-* Ensure that we only accept change requests from people who are authorised
-* Generate data about how much staff time is spent on each client's issues.
-
-If a client asks us to do something in person, on the phone or via email, we
-ask them to visit the [dxw Zendesk](https://dxw.zendesk.com/),
-and submit a ticket there. This is so that:
-
-* We can keep track of the issue from report to solution, and ensure that it's
-  assigned to the right person;
-* We don't risk misunderstanding the problem by writing it down based on a
-  verbal explanation
-* We can formally track the changes that people ask for, by documenting them in
-  tickets that we can look at later if we need to
-
-For these reasons, we do not do any work on a client website or service unless
-we are working during scheduled development time or on a relevant ticket. We think this
-is really important.
-
-#### Support rota
-
-We work on tickets by having a developer on support according to a rota. Developers are assigned to support for one week at a time and work on tickets for the whole week. If there is a ticket they need another developer to help with, this work is scheduled.
-
-#### Client experience (AKA: ticket principles)
-
-##### Be responsive
-
-Clients expect us to deal with their issues promptly. But they understand that this isn't always possible. They are generally forgiving of the fact that we're sometimes busy, and they understand that some issues are complex and require long investigations.
-
-The thing most clients value above all else is being kept informed of what is going on. The first quality of a good ticket experience is responsiveness: we keep clients informed of what we're doing, even if there hasn't been much progress.
-
-##### Stick to your commitments
-
-It's really important that we do what we say we'll do, and don't promise things we can't deliver. If we're unable to deal with a ticket in good time and leave an update saying we'll work on it tomorrow, we must meet that commitment.
-
-It is doubly bad to fail to meet a commitment and not say anything about it. Responsiveness is always the priority. So if for some reason we couldn't do what we said we'd do, we always respond to say so.
-
-##### Make a good impression
-
-In tickets as in all things, we are mindful of dxw's [values](#values).
-
-Most clients' routine contact with us is via support tickets, so it's vital that our clients' experience of the support system is a good one, and also that they have a positive experience with us personally.
-
-We are always considerate, and think about what style of response is best. For example, technical clients may appreciate short, information-dense responses, while non-technical clients might perceive that style as rude or dismissive.
-
-In general:
-
-* We are personable, friendly and helpful
-* If things look like they're going to get difficult or the client seems unhappy, we are honest and assume good faith
-* If we screw something up, we take responsibility and apologise. If the client seems very upset, we let a delivery lead know.
-* If we do become annoyed or frustrated by a ticket, we respond later or speak to a delivery lead about reassigning it.
-
-##### Don't over-deliver
-
-Of course, every client would like us to go the extra mile to solve their problem. But they also understand that to do that for them would mean bad service for another client - or that we never get to their issue, because we're too busy gold-plating the solution to someone else's.
-
-While we do everything we can to make sure the client is happy with our solution, we are also mindful of what's practical. We don't do serious bits of development work on tickets, or trial new approaches. We don't play with new tools or sink hours into interesting bugs. We set those things aside, and do them later.
-
-The main purpose of a ticket is to take some action that solves the problem, as quickly as possible. Generally speaking, we do the most time-efficient thing that we can. Of several potential solutions that solve the problem, assuming none is a bad one, we do the one which can be implemented the most quickly.
-
-#### Deciding what to work on
-
-Developers on support are free to work on whichever tickets they are assigned to and think is most important. But there are some important things to bear in mind.
-
-##### Triage
-
-We all have limited time. We try to spend it wisely. All other things being
-equal, it is better to spend half an hour solving each of four tickets than to
-spend two hours on one issue.
-
-##### Priority
-
-The priority of tickets is important, and we must be biased towards dealing with
-more urgent tickets before less urgent ones.
-
-Each ticket's priority should be reviewed regularly: whenever we update a
-ticket, we check the priority to make sure it's still right.
-
-#### Initial investigation
-
-It's important that we don't make changes unless we thoroughly understand what
-we're being asked to do, and are confident that the client understands and has
-approved of the implications of the change.
-
-##### Replicate the bug
-
-If the issue is a bug, we replicate the behaviour the client has reported before
-working on a fix. It's important that we can reliably and repeatably create the
-conditions necessary for the bug to arise before we start working on it. If we
-don't do this, we can't tell whether we've fixed the problem.
-
-##### Ensure the client has understood and approved the change
-
-When presented with a problem, clients don't always ask us to do the most
-appropriate thing to fix it. Sometimes we can think of a better solution.
-Sometimes the change the client asks for has some implication that they haven't
-considered.
-
-Our helpdesk service is advisory, so we're not afraid to suggest alternative
-approaches and ideas if we have them - including where there's a better
-solution, but [at a cost](#charging-for-ticket-work). We always give options
-when we can.
-
-#### Scope
-
-Clients can use the support service to ask for help with any aspect of the
-service we provide, including help with using the admin panel and advice on getting
-the best out of their site.
-
-But there are some limitations. Under the support service, we do not:
-
-* Add any new functionality requiring anything beyond extremely trivial
-  development. This does not generally include installing plugins: checking and
-  installing plugins is allowed
-* Alter the source code of a plugin or library maintained by a third party
-* Do things that the client can do for themselves in the WordPress
-  administration area. In this situation, help them by letting them know the
-  steps to take to achieve whatever they're trying to do.
-* Other than by prior arrangement, communicate on the client's behalf with the
-  operators of third-party services that the site uses
-* Install a plugin that fails an inspection
-* Do research to identify plugins to solve a particular
-  problem. It's fine to recommend something that we already know of, but in this
-  situation, we usually ask the client to do some searches on the WordPress
-  Directory and suggest one, which we can then check and install.
-* Fix complex problems that come up after a plugin or WordPress core update is
-  applied. Exactly what constitutes a complex problem is at our discretion. But
-  if we've spent a couple of hours on an update-related bug and it's still not fixed,
-  we're probably dealing with one.
-* From time to time, we may make an exception to these restrictions. If you
-  think that might be appropriate, ask a delivery lead. In all the
-  above cases, we can offer to quote for the required work.
-
-#### Charging for ticket work
-
-If you decide that a ticket asks for work to be done which falls outside this
-scope, then the work is chargeable. In this situation, we reassign the ticket to
-a delivery lead or someone from the client services team with an explanation.
-
-It is good to try to think of alternative approaches that we could do under our
-support service before taking this step - seek advice if you're unsure.
-
-The person you assign the ticket to will then treat it as a
-[lead](#leads), and contact the client to make a plan.
-
-## Sales
-
-### Typical projects
-
-Most of our projects are to  research, design , build and support  digital services for the public sector and organisations focused on work for ‘public good’. Broadly speaking, they are usually transactional services ([making payments, bookings, reporting things](https://www.youtube.com/watch?v=NN5B9rL_Hxs) or informational services ([corporate websites](https://www.judiciary.uk/), [campaigns](https://firekills.campaign.gov.uk), intranets) . Sometimes they're a bit of both.
-
-In so doing, we try to make sure that the organisations we're working with will be able to operate their new services well and sustainably. This sometimes involves work that an agency might not normally do, like advising an organisation's leaders on how their teams could be restructured, or on what their digital strategy could be.
-
-With the development of dxw digital’s strategy team, we are increasingly  targeting more strategy-shaped opportunities, to help our clients prepare for, or improve the delivery of digital projects.
-
-We also help clients host some of the services that we build, and by selling subscription-based products that are related to the rest of our work.
-
-### Opportunities
-
-We bid on opportunities through a range of channels.
-
-Some  of our opportunities  arrive directly, often via email, as a result of recommendations, word-of-mouth or through our active engagement and networking in the digital and public sector community.
-
-We also take on work that is received for existing services via helpdesk tickets.
-
-Most of the larger opportunities we bid on  arrive via more formal channels like public sector framework agreements such as the Digital Marketplace.
-
-When any opportunity arrives, we record it in our CRM tool, Hubspot.  This happens automatically for  opportunities published on the Digital Marketplace Outcomes and Specialists framework. Other opportunities are entered individually into Hubspot if they arrive to a specific person.
-
-We record as much information as we can about opportunities when they arrive. An opportunity should be described in enough detail that someone else in the team could pick it up and work on it if needs be. That means that we always record a sensible name, the details of the organisation and where possible, we associate the opportunity to the Hubspot contact and company record of the person we're talking to. If they have provided any documents, we upload those into Hubspot as well.
-
-Opportunities go through several stages during their life, to show whether we're waiting for more information, waiting for a meeting, writing a proposal and so on. For opportunities that we’re bidding on via the Digital Marketplace, our process mirrors the timelines buyers publish in alignment with these standard procurement rules.
-
-When the process ends, a lead will either be [won](#winning-work) or [lost](#losing-work).
-
-### Screening potential projects
-
-At dxw our mission is to help create public services that improve people’s lives. Whether we achieve this depends a lot on the work we choose to do.
-We encourage an open and honest discussion about which work we take on. And we actively seek different perspectives, both inside and outside of dxw.
-
-To decide whether a potential project is ethical and supports our mission, we consider:
-* **Value**
-
-  The work is beneficial to the public, the client and dxw.
-
-* **Practicality**
-
-  We can produce a great result within the likely constraints.
-
-* **Culture**
-
-  We can work together with the client, the users and other stakeholders in ways that support our [values](#values) and [principles](#principles).
-
-### Matching people to projects
-
-We understand that members of staff may have ethical, religious or other concerns about working on a particular project.
-If you do have concerns about a project, please raise them with your line manager or head of profession.
-
-### Budgets
-
-Clients aren’t always able to talk about their budgets, but [we do need to know](https://medium.com/@monteiro/why-i-need-to-know-your-budget-a61ec864c898). If they absolutely can't tell us, we do our best to estimate at what it probably is, based on the information we have.
-
-Where we don't think we could do what the client needs within their budget, we explore alternative options with them that are more affordable. Sometimes this works out, sometimes not. That's ok. Where it does, it tends to be because we've made a good case that it's better to have a small feature set that works really well than a large one that's slightly disappointing.
-
-Where clients have a larger budget than we think they need, we say that too. This usually means explaining why we're able to do the work for less than they thought. We also think about what extra things we could do to improve their chances of success and suggest extra work they could do.
-
-Where a budget is disclosed that's more than we think is necessary, we usually propose a piece of work that uses that budget fully. But we're always open, and tell them that we've done this, and that we'd be delivering more than the minimum. And we're always happy to win a smaller bit of work than the client thought they'd need. We try to structure these proposals so that the extra work is easy to remove.
-
-### Sales meetings
-
-Wherever possible, we meet prospective clients before writing a proposal. This is because face-to-face conversation is the most efficient way to communicate, and the projects we bid for are often complex. Sometimes, this meeting is the way we qualify an opportunity.
-
-By the end of this meeting, we should make sure that we understand:
-
-* Who the client's users are
-* The user needs the client is trying to meet
-* Their current vision for how those needs will be met
-* Any notable technical requirements
-* What the project's budget and deadlines are
-* How many suppliers are likely to be bidding
-* When they need to receive our proposal by
-
-This meeting usually involves quite a bit of discussion about the project. In
-those discussions, we speak freely and openly, offering advice where appropriate
-and making any suggestions we might have. We always try to be as [helpful](#helpful),
-[positive](#positive) and [creative](#creative) as we can.
-
-It's important that we use this meeting to find out the information that we need
-to write a good proposal. But it's just as important to prove our expertise, to
-deliver value early and to leave the client with a positive first impression.
-
-### Proposals and tenders
-
-If the project is being tendered via a fixed process (such as the Digital Marketplace, ) we'll respond by following the process  that the client requests.
-
-Bid writing is a team sport at dxw, so it’s important to involve the potential delivery team in the planning, writing and reviewing of the bid. This is important as it helps to set the team up for a successful pitch (if we need to do one) and eventual delivery if we win the work.
-
-Whilst the process tends to be similar, not all opportunities are exactly the same, for example, sometimes we’ll be provided will a form to complete, and other times we’ll have more flexibility on the format of our proposal.
-
-If we're writing a proposal following our own format, we often start from a proposal template. The main things we’ll often need to write are:
-
-* A description of the project's background. How did they get to the point they're at now?
-* A description of the client's vision. What are they trying to do?
-* An initial set of user needs. How does the client believe their service or project will make things better for these people?
-* Details of how we’ll approach the work
-* A proposed team to do the work, their roles and profiles.
-* How many sprints we estimate we will we need to deliver the work.
-* A timeline for when we expect the sprints and other work will happen.
-* A cost for the work.
-
-There are lots of examples of these proposals that anyone at dxw can read if they like.
-
-### Winning work
-
-When we win work, we mark it as Won in Hubspot. We amend the budget, closing date and services sold if necessary. We write to the client to thank them and ask them for a convenient time to meet and talk about how and when we’ll start the work. We talk to the scheduling team and add the project's sprints and other work to our scheduling tool 10000ft, so that the team can see who's working on what. And we talk to the finance team so that invoices can be created as drafts in our finance system Xero, so we don't forget to bill them.
-
-### Losing work
-
-We don’t always win work we bid for, particularly when it is run via a competitive tendering process, such as on the Digital Outcomes and Specialists framework.
-
-When we lose work, we mark it as Lost in Hubspot. We write to the client to thank them for their interest and ask them for any feedback they might have. We usually also say that we'd be happy to talk about any future work they might have. We record the main reason we didn't win the work in Hubspot along with the detailed feedback.
-
-We do our best to incorporate this feedback into future bids.
-
-Some opportunities, upon review with the team or following discussions with the client, turn out not to be dxw-shaped things. This could be for lots of reasons - capacity, capability, location and so on. This is okay. When this happens, we update the client as soon as we can, explaining the reasons for our decision.  We mark these opportunities as No bid in Hubspot, recording the main reason we made this decision, along with any context.
 
 ## Recruitment
 


### PR DESCRIPTION
Moved the material on working with clients into one section
This will need some restructuring now it's together, for example, there's quite a lot of overlap and repetition in different sections, and we now have a great set of delivery guides that should link to this.
The Sharing section should also move here as Sharing our experience and expertise, but there's already a pull requests about that section so I think we'll need to do that separately