### PR TITLE
Improve sidebar visual hierarchy

### DIFF
--- a/build/assets/css/styles.css
+++ b/build/assets/css/styles.css
@@ -101,12 +101,10 @@ b,strong {
 .app-nav li ul li, .sidebar ul li a {
   font-size: 13pt;
 }
-.sidebar ul ul ul li a {
-  font-size: 11pt;
-}
 .app-nav li ul {
   z-index: 99;
 }
+
 article p a, article li a {
   color: inherit;
 }
@@ -182,10 +180,34 @@ a.skip:hover {
   display: inline-block;
 }
 
-[data-page="playbook.md"] .sidebar-nav > ul > li {
+/* Hide <h1> level in sidebar */
+.sidebar-nav > ul > li {
   display: none;
-}
-
-[data-page="playbook.md"] .sidebar-nav > ul > ul {
   margin-left: 0;
 }
+
+/* Sidebar overrides - playbook page */
+/* First level */
+body[data-page="playbook.md"] .sidebar ul > ul > li { padding-top: 15px }
+body[data-page="playbook.md"] .sidebar ul > ul > li a { font-weight: 700; font-size: 13pt; }
+
+/* Second level */
+body[data-page="playbook.md"] .sidebar ul > ul > ul { margin-left: 0; }
+
+/* Undo changes in subsequent levels */
+body[data-page="playbook.md"] .sidebar ul > ul > ul li { padding-top: 0; }
+body[data-page="playbook.md"] .sidebar ul > ul > ul li a { font-weight: 400; font-size: 11pt; }
+body[data-page="playbook.md"] .sidebar ul > ul > ul > ul { margin-left: 15px }
+
+/* Sidebar overrides - guides page */
+/* First level */
+body:not([data-page="playbook.md"]) .sidebar ul > li { padding-top: 15px }
+body:not([data-page="playbook.md"]) .sidebar ul > li a { font-weight: 700; font-size: 13pt; }
+
+/* Second level */
+body:not([data-page="playbook.md"]) .sidebar ul > ul { margin-left: 0; }
+
+/* Undo changes in subsequent levels */
+body:not([data-page="playbook.md"]) .sidebar ul > ul > ul li { padding-top: 0; }
+body:not([data-page="playbook.md"]) .sidebar ul > ul > ul li a { font-weight: 400; font-size: 11pt; }
+body:not([data-page="playbook.md"]) .sidebar ul > ul > ul > ul { margin-left: 15px }


### PR DESCRIPTION
Improve the visual hierarchy of the sidebar to improve readability (thanks @johnwaterworth!)

<img width="285" alt="Screenshot 2020-05-21 at 16 36 46" src="https://user-images.githubusercontent.com/3166/82577115-6de50200-9b82-11ea-9d7d-cc4013f29cc6.png">

NB: The semantic structure of the guide pages are different to the playbook, so I had to implement the styling twice using attribute selectors to do the heavy-lifting.

<img width="286" alt="Screenshot 2020-05-21 at 18 59 50" src="https://user-images.githubusercontent.com/3166/82590243-49465580-9b95-11ea-9ae8-cfda27d3af29.png">