### PR TITLE
Remove CNAME and .nojekyll

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-playbook.dxw.com

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,6 @@ exclude:
   - babel.config.js
   - Brewfile
   - Brewfile.lock.json
-  - CNAME
   - CONTRIBUTING.md
   - package-lock.json
   - package.json


### PR DESCRIPTION
We don't need them anymore because the `gh-pages` branch is the source of the site now, and they're committed over there.