### PR TITLE
Remove double headings

### DIFF
--- a/guides/managing.md
+++ b/guides/managing.md
@@ -2,8 +2,6 @@
 title: Managing the Playbook
 ---
 
-# Managing the Playbook
-
 This is the content strategy for dxw Playbook.
 
 It describes the purpose and users of the Playbook, the kinds of material it

--- a/guides/tone-of-voice.md
+++ b/guides/tone-of-voice.md
@@ -2,8 +2,6 @@
 title: Tone of voice
 ---
 
-# Tone of voice
-
 This is an overview of how we write and should apply to all the writing we do in
 dxw. It’s an important part of how we present ourselves to the outside world,
 alongside our new dxw brand. You can find the brand guidelines and all the


### PR DESCRIPTION
We add the page title as a heading to the page, so no need to specify it again.