### PR TITLE
Make the sidebar toggle a translucent overlay on small screens

### DIFF
--- a/_stylesheets/styles.scss
+++ b/_stylesheets/styles.scss
@@ -444,7 +444,8 @@ body.close {
     transition: background-color 0.3s 0.25s;
 
     @include small-screen {
-      background-color: $teal;
+      background-color: rgba(0, 0, 0, 0.25);
+      width: 300px;
       padding: 20px;
     }
 


### PR DESCRIPTION
Using a solid colour makes it really unclear where the sidebar ends and the interactive toggle begins. This draws a visible boundary and stops obscuring sidebar entries.

![image](https://user-images.githubusercontent.com/1027364/85012851-90574480-b15b-11ea-89b0-240ac9d26ade.png)