### PR TITLE
Replace the search highlight case insensitively

### DIFF
--- a/_javascript/lib/search.js
+++ b/_javascript/lib/search.js
@@ -7,18 +7,16 @@ export default () => {
   const clearButton = document.querySelector(".clear-button");
 
   const getExcerpt = (result, query) => {
+    const queryRegex = new RegExp(query, "i");
     const content = result.dataset.content;
-    const searchIndex = content.search(new RegExp(query, "i"));
+    const searchIndex = content.search(queryRegex);
     const queryLength = query.length;
     const excerpt = content.slice(
       searchIndex - 20,
       searchIndex + queryLength + 20
     );
 
-    return excerpt.replace(
-      query,
-      "<em class='search-keyword'>" + query + "</em>"
-    );
+    return excerpt.replace(queryRegex, "<em class='search-keyword'>$&</em>");
   };
 
   searchBox.addEventListener("input", () => {


### PR DESCRIPTION
Before this change, searching for e.g. `test` would highligh all instances of `test`, but not of `Test`.