### PR TITLE
Remove the edit link from pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,14 +49,6 @@
     <main>
       <section class="content">
         <article class="markdown-section" id="main">
-          <div style="overflow: auto;">
-            <p style="float: right;">
-              <a
-                href="https://github.com/dxw/playbook/edit/master/{{ page.path }}"
-                >Edit document</a
-              >
-            </p>
-          </div>
           <h1>{{ page.title }}</h1>
           {{ content }}
         </article>


### PR DESCRIPTION
Now we're splitting them up they don't match the URLs.