### PR TITLE
Pin Doscify to the version we're building against

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "copy-webpack-plugin": "^6.0.2",
     "core-js": "^3.6.5",
     "css-loader": "^3.6.0",
-    "docsify": "^4.5.5",
+    "docsify": "4.11.3",
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",


### PR DESCRIPTION
We only use the styles and none of the code, so we don't want to accidentally update the version and break our styling.