### PR TITLE
Increase the sidebar bottom margin on small screens

### DIFF
--- a/_stylesheets/styles.scss
+++ b/_stylesheets/styles.scss
@@ -286,6 +286,10 @@ strong {
     padding-bottom: 0;
     margin: 30px 15px;
 
+    @include small-screen {
+      margin-bottom: 70px;
+    }
+
     > h1 {
       margin: 30px 20px;
       font-size: 17pt;


### PR DESCRIPTION
The toggle overlaps the sidebar on small screen, so we need some extra space at the bottom.