### PR TITLE
Replace emoji invocation with actual emoji

### DIFF
--- a/guides/plugin-advisories.md
+++ b/guides/plugin-advisories.md
@@ -159,7 +159,7 @@ Their policy is this:
 - [ ] Hit the "WP Plugins" button under "Report emails"
 - [ ] Add a note to the timeline - e.g. 2014-01-02: Reported to WP Plugins
 
-### :rotating_light: IMPORTANT :rotating_light:
+### ⚠️ IMPORTANT ⚠️
 
 If we couldn’t get in touch with the plugin author then WP Org may be able to
 contact them on our behalf, BUT we shouldn’t expect them to feed back any


### PR DESCRIPTION
Since the move to Jekyll, emoji nicknames are not compiled into actual emoji anymore.

I have chosen to use a different emoji than the original, since I think it’s more adequate for conveying the meaning of “warning”.