### PR TITLE
Front matter always present for guides

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,8 @@ gem "foreman"
 gem "jekyll"
 gem "nokogiri"
 gem "standard"
+
+group :jekyll_plugins do
+  gem 'pry'
+  gem 'jekyll_frontmatter_tests'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gem "nokogiri"
 gem "standard"
 
 group :jekyll_plugins do
-  gem 'pry'
-  gem 'jekyll_frontmatter_tests'
+  gem "pry"
+  gem "jekyll_frontmatter_tests"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
+    coderay (1.1.3)
     colorator (1.1.0)
     concurrent-ruby (1.1.7)
     em-websocket (0.5.2)
@@ -35,6 +36,7 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    jekyll_frontmatter_tests (0.0.4)
     kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -44,6 +46,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    method_source (1.0.0)
     mini_portile2 (2.4.0)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -52,6 +55,9 @@ GEM
       ast (~> 2.4.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.6)
     rainbow (3.0.0)
     rb-fsevent (0.10.4)
@@ -91,7 +97,9 @@ PLATFORMS
 DEPENDENCIES
   foreman
   jekyll
+  jekyll_frontmatter_tests
   nokogiri
+  pry
   standard
 
 BUNDLED WITH

--- a/deploy/tests/schema/_posts.yml
+++ b/deploy/tests/schema/_posts.yml
@@ -3,7 +3,7 @@ title: "String"
 config:
   path: "guides"
   ignore:
-  - "README.md"
-  - ..
-  - .
-  - .DS_Store
+    - "README.md"
+    - ..
+    - .
+    - .DS_Store

--- a/deploy/tests/schema/_posts.yml
+++ b/deploy/tests/schema/_posts.yml
@@ -1,0 +1,9 @@
+title: "String"
+
+config:
+  path: "guides"
+  ignore:
+  - "README.md"
+  - ..
+  - .
+  - .DS_Store

--- a/script/test
+++ b/script/test
@@ -37,5 +37,8 @@ else
   npm run lint
 fi
 
+echo "==> Checking for required frontmatter..."
+bundle exec jekyll test
+
 echo "==> Testing..."
 npm test


### PR DESCRIPTION
`jekyll_frontmatter_tests` gem has been implemented to check that each markdown page contains a front matter, with a title present.
This test has been added to CI tests to ensure this check happens automatically. 
