### PR TITLE
Make sure sidebar links jump to the correct place

### DIFF
--- a/_javascript/lib/sidebarNavigation.js
+++ b/_javascript/lib/sidebarNavigation.js
@@ -3,10 +3,21 @@ export default (links) => {
     element.classList.add("active");
   };
 
+  const getElementLocation = (element) => {
+    const navElement = document.querySelector(".app-nav");
+    const yOffset = navElement.offsetHeight;
+
+    return element.getBoundingClientRect().top + window.pageYOffset - yOffset;
+  };
+
   const scrollToLink = (element) => {
     const locationID = element.getAttribute("data-target");
+    const targetElement = document.getElementById(locationID);
 
-    document.getElementById(locationID).scrollIntoView({ behavior: "smooth" });
+    window.scrollTo({
+      top: getElementLocation(targetElement),
+      behavior: "smooth",
+    });
 
     if (window.innerWidth < 768) {
       const body = document.querySelector("body");

--- a/_spec/javascript/lib/sidebarNavigation.test.js
+++ b/_spec/javascript/lib/sidebarNavigation.test.js
@@ -1,16 +1,17 @@
 import sidebarNavigation from "../../../_javascript/lib/sidebarNavigation";
 
 describe("sidebarNavigation", () => {
-  let scrollIntoViewMock;
+  let scrollToMock;
   let links;
 
   beforeEach(() => {
-    scrollIntoViewMock = jest.fn();
-    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+    scrollToMock = jest.fn();
+    window.scrollTo = scrollToMock;
 
     jest.spyOn(history, "pushState");
 
     document.body.innerHTML = `
+      <nav class="app-nav"></nav>
       <a href="#bar" data-target="bar" class="active"></a>
       <a href="#foo" data-target="foo"></a>
       <div id="foo"></div>
@@ -51,7 +52,7 @@ describe("sidebarNavigation", () => {
 
     link.click();
 
-    expect(scrollIntoViewMock).toHaveBeenCalled();
+    expect(scrollToMock).toHaveBeenCalled();
   });
 
   it("adds the link to the pushState", () => {


### PR DESCRIPTION
Before, we were using `scrollIntoView` to scroll to the target element. This worked, but the headings were often obscured by the nav bar, as the main elements are positioned absolutely on the page. This tweaks the code to get the location of the element on the page and subtract the height of the navbar, so the element we've scrolled to is visible.

## Before

![](http://g.recordit.co/u5pfOh6Hm1.gif)

## After

![](http://g.recordit.co/459pz2wCtw.gif)