### PR TITLE
Set focus correctly

### DIFF
--- a/_javascript/lib/sidebarNavigation.js
+++ b/_javascript/lib/sidebarNavigation.js
@@ -10,22 +10,38 @@ export default (links) => {
     return element.getBoundingClientRect().top + window.pageYOffset - yOffset;
   };
 
-  const scrollToLink = (element) => {
-    const locationID = element.getAttribute("data-target");
+  const scrollToLink = (link) => {
+    const locationID = link.getAttribute("data-target");
     const targetElement = document.getElementById(locationID);
+    const y = getElementLocation(targetElement);
 
     window.scrollTo({
-      top: getElementLocation(targetElement),
+      top: y,
       behavior: "smooth",
     });
 
-    if (window.innerWidth < 768) {
-      const body = document.querySelector("body");
+    const intervalID = setInterval(function () {
+      // Check if the Y Offset has got within 10 pixels of the target
+      // it's not always going to be exact, so make sure we're roughly
+      // there
+      if (Math.abs(y - window.pageYOffset) < 5) {
+        link.blur();
+        // Set focus on the target element. Because it's not an anchor
+        // or form element, we need to give it a tabindex first
+        targetElement.setAttribute("tabindex", "-1");
+        targetElement.focus();
 
-      body.classList.remove("close");
-    }
+        if (window.innerWidth < 768) {
+          const body = document.querySelector("body");
 
-    history.pushState({}, "", "#" + locationID);
+          body.classList.remove("close");
+        }
+
+        history.pushState({}, "", "#" + locationID);
+
+        clearInterval(intervalID);
+      }
+    }, 300);
   };
 
   for (const link of links) {

--- a/_spec/javascript/lib/sidebarNavigation.test.js
+++ b/_spec/javascript/lib/sidebarNavigation.test.js
@@ -9,6 +9,7 @@ describe("sidebarNavigation", () => {
     window.scrollTo = scrollToMock;
 
     jest.spyOn(history, "pushState");
+    jest.useFakeTimers();
 
     document.body.innerHTML = `
       <nav class="app-nav"></nav>
@@ -62,6 +63,8 @@ describe("sidebarNavigation", () => {
 
     link.click();
 
+    jest.runAllTimers();
+
     expect(history.pushState).toHaveBeenCalledWith({}, "", "#foo");
   });
 
@@ -75,6 +78,8 @@ describe("sidebarNavigation", () => {
     const link = document.querySelector("a[data-target='foo']");
 
     link.click();
+
+    jest.runAllTimers();
 
     expect(document.querySelector("body").classList).not.toContain("close");
   });


### PR DESCRIPTION
When we're scrolling to the right part of the page when using the sidebar navigation, the focus remains on the link, which can be confusing for screenreader users. Because `window.scrollTo` doesn't have a callback function, we need to use `setInterval` to poll to see if the page has been scrolled to roughly the right place. If it has, we remove focus from the clicked link, and set focus to the target heading element.