### PR TITLE
Remove -p flag from production build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "webpack-cli": "^4.1.0"
   },
   "scripts": {
-    "build": "webpack -p --mode=production",
+    "build": "webpack --mode=production",
     "build:dev": "webpack --mode=development",
     "build:dev:watch": "npm run build:dev -- --watch",
     "test": "jest",


### PR DESCRIPTION
The `-p` flag has been removed in Webpack 4.x. See https://github.com/webpack/webpack-cli/pull/1688