### PR TITLE
Fix Github Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,8 @@ jobs:
 
       - name: Set language versions
         run: |
-          echo "::set-env name=GO_VERSION::$(cat .go-version)"
-          echo "::set-env name=NODE_VERSION::$(cat .node-version)"
-          echo "::set-env name=RUBY_VERSION::$(cat .ruby-version)"
+          echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
+          echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
 
       - uses: actions/setup-go@v2
         with:
@@ -27,9 +26,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - uses: actions/setup-ruby@v1.1.2
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+      - uses: ruby/setup-ruby@v1
 
       - name: Set up Bundler
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,8 @@ jobs:
 
       - name: Set language versions
         run: |
-          echo "::set-env name=GO_VERSION::$(cat .go-version)"
-          echo "::set-env name=NODE_VERSION::$(cat .node-version)"
-          echo "::set-env name=RUBY_VERSION::$(cat .ruby-version)"
+          echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
+          echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
 
       - uses: actions/setup-go@v2
         with:
@@ -26,9 +25,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - uses: actions/setup-ruby@v1.1.2
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+      - uses: ruby/setup-ruby@v1
 
       - name: Install ShellCheck
         run: |


### PR DESCRIPTION
Due to a security vulnerability, Github Actions no longer supports `set-env` (https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/). This updates us to the new way of setting environment variables, to set language dependencies, as well as moving to [ruby/setup-ruby](https://github.com/ruby/setup-ruby), which supports implicit versioning from the `.ruby-version` file.