### PR TITLE
Do not use the dxw style on tone-of-voice.md

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -16,3 +16,5 @@ proselint.GenderBias = YES
 write-good.So = warning
 write-good.ThereIs = warning
 proselint.Cliches = warning
+proselint.DateSpacing = suggestion
+proselint.DateCase = suggestion

--- a/.vale.ini
+++ b/.vale.ini
@@ -15,3 +15,4 @@ proselint.LGBTTerms = YES
 proselint.GenderBias = YES
 write-good.So = warning
 write-good.ThereIs = warning
+proselint.Cliches = warning

--- a/.vale.ini
+++ b/.vale.ini
@@ -18,3 +18,4 @@ write-good.ThereIs = warning
 proselint.Cliches = warning
 proselint.DateSpacing = suggestion
 proselint.DateCase = suggestion
+proselint.Skunked = suggestion

--- a/.vale.ini
+++ b/.vale.ini
@@ -13,4 +13,5 @@ proselint.Cursing = YES
 proselint.LGBTOffensive = YES
 proselint.LGBTTerms = YES
 proselint.GenderBias = YES
-
+write-good.So = warning
+write-good.ThereIs = warning

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,6 +1,9 @@
 StylesPath = _styles
 MinAlertLevel = warning # suggestion, warning or error
 
+[guides/tone-of-voice.md]
+BasedOnStyles = Govuk, proselint, write-good
+
 [*.md]
 BasedOnStyles = dxw, Govuk, proselint, write-good
 
@@ -10,3 +13,4 @@ proselint.Cursing = YES
 proselint.LGBTOffensive = YES
 proselint.LGBTTerms = YES
 proselint.GenderBias = YES
+

--- a/_includes/sections/our-professions/user-research.md
+++ b/_includes/sections/our-professions/user-research.md
@@ -47,9 +47,9 @@ and working with, not for our clients.
    quality of our methods. We use tried and tested methods, and take time to
    reflect and continually improve our practice.
 
-   We also understand that context is important. So we use the best approach
-   for the question at hand and adapt our ways of working to fit the client and
-   the project.
+   We also understand that context is important. So we use the best approach for
+   the question at hand and adapt our ways of working to fit the client and the
+   project.
 
 1. **Learn, share and adapt**
 

--- a/_includes/sections/our-professions/user-research.md
+++ b/_includes/sections/our-professions/user-research.md
@@ -47,7 +47,7 @@ and working with, not for our clients.
    quality of our methods. We use tried and tested methods, and take time to
    reflect and continually improve our practice.
 
-   But we also understand that context is important. So we use the best approach
+   We also understand that context is important. So we use the best approach
    for the question at hand and adapt our ways of working to fit the client and
    the project.
 

--- a/_includes/sections/who-we-are.md
+++ b/_includes/sections/who-we-are.md
@@ -26,10 +26,9 @@ education, health and social care, housing, welfare, and policing.
 
 ### Our values
 
-We think that it's important to have a talented team if we're going to
-succeed. But just as important as raw talent is our ability to work well
-together. These are the values that we aspire to, and help each other to
-achieve.
+We think that it's important to have a talented team if we're going to succeed.
+But just as important as raw talent is our ability to work well together. These
+are the values that we aspire to, and help each other to achieve.
 
 #### Helpful
 
@@ -210,9 +209,9 @@ Remember that this Playbook is the result of our conversations about how we
 should do things, not a substitute for one. So don’t make changes unless they
 reflect our shared agreement about how things are going to be done.
 
-This document is also public, because there is little about our process
-that cannot be open; but there will be some things that should be private. So
-don't forget that changes here get published to the world.
+This document is also public, because there is little about our process that
+cannot be open; but there will be some things that should be private. So don't
+forget that changes here get published to the world.
 
 To update the Playbook, follow the
 [guide to Contributing to the Playbook](/guides/contributing) and use

--- a/_includes/sections/who-we-are.md
+++ b/_includes/sections/who-we-are.md
@@ -206,12 +206,12 @@ Thoughtbot!
 This Playbook is a collaborative effort. Anyone at dxw can and should edit it.
 So if you spot something that’s wrong, feel free to hop in and correct it.
 
-But remember that this Playbook is the result of our conversations about how we
+Remember that this Playbook is the result of our conversations about how we
 should do things, not a substitute for one. So don’t make changes unless they
 reflect our shared agreement about how things are going to be done.
 
 This document is also public, because there is little about our process
-that cannot be open. But there will be some things that should be private. So
+that cannot be open; but there will be some things that should be private. So
 don't forget that changes here get published to the world.
 
 To update the Playbook, follow the

--- a/_includes/sections/who-we-are.md
+++ b/_includes/sections/who-we-are.md
@@ -26,7 +26,7 @@ education, health and social care, housing, welfare, and policing.
 
 ### Our values
 
-We think that it's very important to have a talented team if we're going to
+We think that it's important to have a talented team if we're going to
 succeed. But just as important as raw talent is our ability to work well
 together. These are the values that we aspire to, and help each other to
 achieve.
@@ -121,7 +121,7 @@ However, there are some things that we must keep private.
 
 - Our clients trust us to host content that is not public, like upcoming
   announcements and discussions made as part of formulating new policy. This is
-  not our information to be open about, and it's very important to keep it
+  not our information to be open about, and it's important to keep it
   confidential.
 - We also hold some personal data about and/or on behalf of our clients. We
   never share any of this data, including contact details. See also:
@@ -178,7 +178,7 @@ We are focusing on three main areas to reduce our impact:
 ### Our Advisory Council
 
 dxw does not have external investors or shareholders. To help keep us honest, we
-are very lucky to have a voluntary Advisory Council, made up of a small group of
+are lucky to have a voluntary Advisory Council, made up of a small group of
 senior figures, who meet quarterly to discuss and provide guidance on our
 strategy, business plan and other topics related to company health and
 progression. The group have a wealth of experience of public and private sector
@@ -210,7 +210,7 @@ But remember that this Playbook is the result of our conversations about how we
 should do things, not a substitute for one. So don’t make changes unless they
 reflect our shared agreement about how things are going to be done.
 
-This document is also public, because there is very little about our process
+This document is also public, because there is little about our process
 that cannot be open. But there will be some things that should be private. So
 don't forget that changes here get published to the world.
 

--- a/_includes/sections/work-we-do/building-services.md
+++ b/_includes/sections/work-we-do/building-services.md
@@ -89,7 +89,7 @@ iterate them based on feedback. We also use the alpha phase to carry out
 technical spikes and experiments, and to make initial technology and service
 design decisions.
 
-**Beta**: Build a working version of the service, based on what we learnt in
+**Beta**: Build a working version of the service, based on what we learned in
 alpha. Carry out regular usability testing of the service with users, and launch
 a minimum viable product. Make plans for supporting the service and continue
 iterating it.

--- a/_includes/sections/work-we-do/supporting-services.md
+++ b/_includes/sections/work-we-do/supporting-services.md
@@ -73,7 +73,7 @@ In general:
 - if things look like they're going to get difficult or the client seems
   unhappy, we are honest and assume good faith
 - if we make a mistake, we take responsibility and apologise, and if the client
-  seems very upset, we let the account manager know
+  seems upset, we let the account manager know
 - if we do become annoyed or frustrated by a ticket, we come back to it later
 
 ##### Don't over-deliver

--- a/_includes/sections/working-here/hiring-new-people.md
+++ b/_includes/sections/working-here/hiring-new-people.md
@@ -53,7 +53,7 @@ people who are interested in dxw but who don't fit an open job.
 All applications arrive via Workable. We review these applications as a team to
 decide who to take forward.
 
-An application review is a very quick process. We look at the information given
+An application review is a quick process. We look at the information given
 by the candidate and decide if it is likely that the applicant has the skills,
 experience and personal qualities that we need. If it is likely, we progress
 them to the next stage.
@@ -81,7 +81,7 @@ qualities than about skills. So look for whether this person:
 If you can find out how they heard about the job, that's useful for us to know.
 
 Many people feel self-conscious when asking questions about salary, but it's
-very important - and this is one of the few situations in daily life where
+important - and this is one of the few situations in daily life where
 people expect the question and are not put off by it. If you're not sure how to
 broach the topic, leave it to the end. When you're about to finish the call, you
 can say something like:
@@ -136,11 +136,11 @@ When everything's done, we thank the candidate for their time and then return to
 the office and discuss the interview. As soon as possible, we put a thorough
 update on Workable. This update should include the good things and bad things
 about the candidate, a recommendation on whether to take them forward, and a
-rationale for that recommendation. It is very important that this update is
+rationale for that recommendation. It is important that this update is
 detailed enough for us to understand what happened and why, long after everyone
 involved has forgotten all about it.
 
-If you think the candidate is very likely to have the skills, experience and
+If you think the candidate is likely to have the skills, experience and
 personal qualities we need, you should take them through to a work day.
 
 The work day interview is exactly the same as the first interview, but with

--- a/_includes/sections/working-here/hiring-new-people.md
+++ b/_includes/sections/working-here/hiring-new-people.md
@@ -53,8 +53,8 @@ people who are interested in dxw but who don't fit an open job.
 All applications arrive via Workable. We review these applications as a team to
 decide who to take forward.
 
-An application review is a quick process. We look at the information given
-by the candidate and decide if it is likely that the applicant has the skills,
+An application review is a quick process. We look at the information given by
+the candidate and decide if it is likely that the applicant has the skills,
 experience and personal qualities that we need. If it is likely, we progress
 them to the next stage.
 
@@ -81,10 +81,10 @@ qualities than about skills. So look for whether this person:
 If you can find out how they heard about the job, that's useful for us to know.
 
 Many people feel self-conscious when asking questions about salary, but it's
-important - and this is one of the few situations in daily life where
-people expect the question and are not put off by it. If you're not sure how to
-broach the topic, leave it to the end. When you're about to finish the call, you
-can say something like:
+important - and this is one of the few situations in daily life where people
+expect the question and are not put off by it. If you're not sure how to broach
+the topic, leave it to the end. When you're about to finish the call, you can
+say something like:
 
 "Thanks for talking to me. Before we finish, please could you give me an idea of
 the salary you'd like?"
@@ -136,12 +136,12 @@ When everything's done, we thank the candidate for their time and then return to
 the office and discuss the interview. As soon as possible, we put a thorough
 update on Workable. This update should include the good things and bad things
 about the candidate, a recommendation on whether to take them forward, and a
-rationale for that recommendation. It is important that this update is
-detailed enough for us to understand what happened and why, long after everyone
-involved has forgotten all about it.
+rationale for that recommendation. It is important that this update is detailed
+enough for us to understand what happened and why, long after everyone involved
+has forgotten all about it.
 
-If you think the candidate is likely to have the skills, experience and
-personal qualities we need, you should take them through to a work day.
+If you think the candidate is likely to have the skills, experience and personal
+qualities we need, you should take them through to a work day.
 
 The work day interview is exactly the same as the first interview, but with
 different members of the team and different questions. Usually, it happens in

--- a/_includes/sections/working-here/hiring-new-people.md
+++ b/_includes/sections/working-here/hiring-new-people.md
@@ -26,7 +26,7 @@ skills are a good fit for the job. A good job description has three parts:
    good at their job
 
 There are lots of job descriptions on the website if you need inspiration. It's
-important for them to be declarative ("The person with this job will...") and as
+important for them to be declarative ("The person with this job will…") and as
 objective as possible. Throughout the rest of the process, we'll use this
 document to decide what questions to ask in interviews, and to fix activities
 for the work day. The skills and personal qualities need to be things that we
@@ -168,7 +168,7 @@ TODO. This section to cover:
 - Background check
 - Starters checklist
 - The probation period, meeting and expectations
-- ...more things.
+- …more things.
 
 #### Returners' programme
 

--- a/_includes/sections/working-here/managing-your-day-to-day-work.md
+++ b/_includes/sections/working-here/managing-your-day-to-day-work.md
@@ -14,12 +14,11 @@ late, you should let everyone know in the project Slack channel.
 Most developers have maintenance responsibilities, which they do during their
 [support rotation](#support-rota).
 
-We do our best to
-[work at a sustainable pace](#work-at-a-sustainable-pace). But sometimes, when
-we're approaching a firm deadline or a launch, or a client is having an
-emergency, we work longer hours than normal. From time to time, there's an
-emergency that means we have to work during unsociable hours to solve the
-problem. Neither of these happen often, but they are a normal part of life
+We do our best to [work at a sustainable pace](#work-at-a-sustainable-pace). But
+sometimes, when we're approaching a firm deadline or a launch, or a client is
+having an emergency, we work longer hours than normal. From time to time,
+there's an emergency that means we have to work during unsociable hours to solve
+the problem. Neither of these happen often, but they are a normal part of life
 at dxw.
 
 Sending emails or posting in Slack outside of working hours can be a good way to

--- a/_includes/sections/working-here/managing-your-day-to-day-work.md
+++ b/_includes/sections/working-here/managing-your-day-to-day-work.md
@@ -14,12 +14,12 @@ late, you should let everyone know in the project Slack channel.
 Most developers have maintenance responsibilities, which they do during their
 [support rotation](#support-rota).
 
-We do our very best to
+We do our best to
 [work at a sustainable pace](#work-at-a-sustainable-pace). But sometimes, when
 we're approaching a firm deadline or a launch, or a client is having an
 emergency, we work longer hours than normal. From time to time, there's an
 emergency that means we have to work during unsociable hours to solve the
-problem. Neither of these happen very often, but they are a normal part of life
+problem. Neither of these happen often, but they are a normal part of life
 at dxw.
 
 Sending emails or posting in Slack outside of working hours can be a good way to

--- a/guides/being-a-tech-lead-at-dxw.md
+++ b/guides/being-a-tech-lead-at-dxw.md
@@ -2,9 +2,9 @@
 title: Being a tech lead at dxw
 ---
 
-## Being a tech lead...
+## Being a tech lead…
 
-### ...at an agency
+### …at an agency
 
 Our work with a client is always temporary. Sometimes we know the end before we
 start, and sometimes it seems like it will go on forever. But eventually the
@@ -73,7 +73,7 @@ risk they're prepared to carry. We often have to do some amount of mediation in
 that case (usually biased towards delivery - it's what we're there for after
 all).
 
-### ...for public services
+### …for public services
 
 The public sector has a history of abdicating digital and technology decisions
 to suppliers. That's caused a loss of the expertise needed even to make sound
@@ -102,7 +102,7 @@ short tenure for those technologists they do manage to hire. But it also means
 you'll often be working with folks who are motivated more by doing public good
 than they are by chasing money.
 
-### ...at the intersection of the two
+### …at the intersection of the two
 
 When building a public service, it can be hard to ever call it done. Especially
 when much of your team's time is spent dealing with broken foundations (lack of

--- a/guides/being-a-tech-lead-at-dxw.md
+++ b/guides/being-a-tech-lead-at-dxw.md
@@ -77,10 +77,10 @@ all).
 
 The public sector has a history of abdicating digital and technology decisions
 to suppliers. That's caused a loss of the expertise needed even to make sound
-decisions about those suppliers. That's slowly changing, but it's still
-normal to be working with (passionate, driven, experienced) civil servants who
-haven't worked in an agile way, who don't know how software is built, and who
-don't know how much software costs.
+decisions about those suppliers. That's slowly changing, but it's still normal
+to be working with (passionate, driven, experienced) civil servants who haven't
+worked in an agile way, who don't know how software is built, and who don't know
+how much software costs.
 
 That means part of your role is education. For the public sector to properly
 complete their digital transformation, it's not enough to put some services on
@@ -129,8 +129,8 @@ architect) to help, and call on the wider dxw team when you need it.
 ## What our tech leads do inside teams
 
 The role of a tech lead at dxw is to lead the technical work of the team. Given
-software is built by and for people, that means it's at the squishy
-intersection of technical expertise and people skills.
+software is built by and for people, that means it's at the squishy intersection
+of technical expertise and people skills.
 
 A tech lead's job is to:
 
@@ -158,7 +158,7 @@ decisions, and communicate those with the team and stakeholders.
 
 A lot of those points overlap to various degrees with things a delivery lead or
 product manager do. The relationship between the tech lead and the people in
-those roles is important. Addressing issues with team processes is a lot
-easier when done together with the delivery lead. Ensuring the team understands
-the domain and that developers are included early enough in story planning
-should be done with the help of the product manager.
+those roles is important. Addressing issues with team processes is a lot easier
+when done together with the delivery lead. Ensuring the team understands the
+domain and that developers are included early enough in story planning should be
+done with the help of the product manager.

--- a/guides/being-a-tech-lead-at-dxw.md
+++ b/guides/being-a-tech-lead-at-dxw.md
@@ -77,7 +77,7 @@ all).
 
 The public sector has a history of abdicating digital and technology decisions
 to suppliers. That's caused a loss of the expertise needed even to make sound
-decisions about those suppliers. That's slowly changing, but it's still very
+decisions about those suppliers. That's slowly changing, but it's still
 normal to be working with (passionate, driven, experienced) civil servants who
 haven't worked in an agile way, who don't know how software is built, and who
 don't know how much software costs.
@@ -129,7 +129,7 @@ architect) to help, and call on the wider dxw team when you need it.
 ## What our tech leads do inside teams
 
 The role of a tech lead at dxw is to lead the technical work of the team. Given
-software is built by and for people, that means it's very much at the squishy
+software is built by and for people, that means it's at the squishy
 intersection of technical expertise and people skills.
 
 A tech lead's job is to:
@@ -158,7 +158,7 @@ decisions, and communicate those with the team and stakeholders.
 
 A lot of those points overlap to various degrees with things a delivery lead or
 product manager do. The relationship between the tech lead and the people in
-those roles is very important. Addressing issues with team processes is a lot
+those roles is important. Addressing issues with team processes is a lot
 easier when done together with the delivery lead. Ensuring the team understands
 the domain and that developers are included early enough in story planning
 should be done with the help of the product manager.

--- a/guides/claiming-expenses.md
+++ b/guides/claiming-expenses.md
@@ -26,13 +26,13 @@ Each receipt requires the following details:
   icon. Use this to upload a photograph or scan of your receipt. If you upload a
   photograph, make sure it's legible.
 - **Description, quantity and unit price**:: Add the the description of the line
-  item on the receipt. If that text is not very descriptive, though, consider
+  item on the receipt. If that text is not descriptive, though, consider
   elaborating. Add the quantity and the price of an individual item.
 - **Account**:: See below.
 - **Tax rate**:: The tax rate will be set automatically from the account you
   select, however you must check that it is correct. Check your receipt to see
   what VAT, if any, was charged. If you cannot see a reference to VAT, select No
-  VAT in this field. It is very important to get this right as this data feeds
+  VAT in this field. It is important to get this right as this data feeds
   directly into our VAT returns.
 - **Products**:: If the expense relates to a particular area of work (at the
   time of writing: Agency, Hosting or Citrulu), select the applicable product.

--- a/guides/office-accessibility.md
+++ b/guides/office-accessibility.md
@@ -84,7 +84,7 @@ main room and 1.9 m in the back room.
 
 The floors on the ground level are laminated wood.
 
-Very little natural light. The lighting is provided by white LED spotlights on
+Little natural light. The lighting is provided by white LED spotlights on
 ceiling and wall lights, and yellow lightbulb fixures on the ceiling.
 
 2 of the desks are easily adjustable for height. There are ergonomic chairs.

--- a/guides/plugin-advisories.md
+++ b/guides/plugin-advisories.md
@@ -65,7 +65,7 @@ Description:
 or maybe:
 
 > If an attacker is able to convince a logged-in admin user to follow a link
-> (phishing emails can be made to look extremely convincing), then ...
+> (phishing emails can be made to look extremely convincing), then …
 
 Proof of concept:
 
@@ -83,7 +83,7 @@ server
 Description:
 
 If there are classes with methods like `__destruct()` that have certain
-properties, the attacker can ...
+properties, the attacker can …
 
 ### Mitigations
 

--- a/guides/plugin-advisories.md
+++ b/guides/plugin-advisories.md
@@ -65,7 +65,7 @@ Description:
 or maybe:
 
 > If an attacker is able to convince a logged-in admin user to follow a link
-> (phishing emails can be made to look very convincing), then ...
+> (phishing emails can be made to look extremely convincing), then ...
 
 Proof of concept:
 

--- a/guides/plugin-reviews.md
+++ b/guides/plugin-reviews.md
@@ -69,8 +69,8 @@ they represent real issues.
 If the plugin is large (around 15,000 or more lines of code), start with a line
 like this:
 
-> At over 26,000 lines of PHP this is a large plugin, which makes it
-> difficult to thoroughly assess
+> At over 26,000 lines of PHP this is a large plugin, which makes it difficult
+> to thoroughly assess
 
 ### Recommendations
 

--- a/guides/plugin-reviews.md
+++ b/guides/plugin-reviews.md
@@ -69,7 +69,7 @@ they represent real issues.
 If the plugin is large (around 15,000 or more lines of code), start with a line
 like this:
 
-> At over 26,000 lines of PHP this is a very large plugin, which makes it
+> At over 26,000 lines of PHP this is a large plugin, which makes it
 > difficult to thoroughly assess
 
 ### Recommendations

--- a/guides/service-design-at-dxw.md
+++ b/guides/service-design-at-dxw.md
@@ -126,7 +126,7 @@ experience of applying service design to projects at dxw.
   with the technology and processes that surround them. Service designers help
   manage these **technical and non-technical interfaces**.
 
-## 7. Beta, live and beyond...
+## 7. Beta, live and beyond…
 
 - Service designers like to be involved throughout the beta and live phases of a
   new service to help ensure that **performance is tracked and outcomes

--- a/guides/setting-up-a-new-project.md
+++ b/guides/setting-up-a-new-project.md
@@ -16,10 +16,10 @@ few weeks long.
 
 ## Before a project starts
 
-In most cases, there’s not a long lead time between winning a piece of work
-and starting it. We sometimes have a number of days, rather than weeks, for the
-team to get everything in place. This includes things like contracts, scheduling
-a team to do the work and making a plan for the first few days.
+In most cases, there’s not a long lead time between winning a piece of work and
+starting it. We sometimes have a number of days, rather than weeks, for the team
+to get everything in place. This includes things like contracts, scheduling a
+team to do the work and making a plan for the first few days.
 
 We’re lucky if the same delivery lead has been involved in the sales work that
 led to the project being won, because there’s always other work in flight. It’s

--- a/guides/setting-up-a-new-project.md
+++ b/guides/setting-up-a-new-project.md
@@ -16,7 +16,7 @@ few weeks long.
 
 ## Before a project starts
 
-In most cases, there’s not a very long lead time between winning a piece of work
+In most cases, there’s not a long lead time between winning a piece of work
 and starting it. We sometimes have a number of days, rather than weeks, for the
 team to get everything in place. This includes things like contracts, scheduling
 a team to do the work and making a plan for the first few days.
@@ -147,7 +147,7 @@ be doing on the project. Some further ideas:
 
 There are a number of outcomes you should aim to get out of a kick-off. This is
 important especially if we are working with that client for the first time and
-there are areas that are not very clear to us, or to them. You can structure a
+there are areas that are not clear to us, or to them. You can structure a
 kick-off in the way that works best for you, but some frameworks that will help
 you get the outcomes you need are below:
 


### PR DESCRIPTION
tone-of-voice.md contains several "incorrect" examples. The linter is treating
these as errors (correctly) but we want them to be present to show what not
to write. Ignore this file with the dxw style to mitigate these errors.