### PR TITLE
Fix prose linting on existing playbook content

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -16,3 +16,5 @@ proselint.GenderBias = YES
 write-good.So = warning
 write-good.ThereIs = warning
 proselint.Cliches = warning
+proselint.DateSpacing = suggestion
+proselint.DateCase = suggestion

--- a/.vale.ini
+++ b/.vale.ini
@@ -19,3 +19,4 @@ proselint.Cliches = warning
 proselint.DateSpacing = suggestion
 proselint.DateCase = suggestion
 proselint.Skunked = suggestion
+proselint.Very = suggestion

--- a/.vale.ini
+++ b/.vale.ini
@@ -15,3 +15,4 @@ proselint.LGBTTerms = YES
 proselint.GenderBias = YES
 write-good.So = warning
 write-good.ThereIs = warning
+proselint.Cliches = warning

--- a/.vale.ini
+++ b/.vale.ini
@@ -18,3 +18,4 @@ write-good.ThereIs = warning
 proselint.Cliches = warning
 proselint.DateSpacing = suggestion
 proselint.DateCase = suggestion
+proselint.Skunked = suggestion

--- a/.vale.ini
+++ b/.vale.ini
@@ -13,4 +13,5 @@ proselint.Cursing = YES
 proselint.LGBTOffensive = YES
 proselint.LGBTTerms = YES
 proselint.GenderBias = YES
-
+write-good.So = warning
+write-good.ThereIs = warning

--- a/.vale.ini
+++ b/.vale.ini
@@ -20,3 +20,4 @@ proselint.DateSpacing = suggestion
 proselint.DateCase = suggestion
 proselint.Skunked = suggestion
 proselint.Very = suggestion
+proselint.RASSyndrome = warning

--- a/.vale.ini
+++ b/.vale.ini
@@ -15,6 +15,7 @@ proselint.LGBTTerms = YES
 proselint.GenderBias = YES
 write-good.So = warning
 write-good.ThereIs = warning
+proselint.But = warning
 proselint.Cliches = warning
 proselint.DateSpacing = suggestion
 proselint.DateCase = suggestion

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,6 +1,9 @@
 StylesPath = _styles
 MinAlertLevel = warning # suggestion, warning or error
 
+[guides/tone-of-voice.md]
+BasedOnStyles = Govuk, proselint, write-good
+
 [*.md]
 BasedOnStyles = dxw, Govuk, proselint, write-good
 
@@ -10,3 +13,4 @@ proselint.Cursing = YES
 proselint.LGBTOffensive = YES
 proselint.LGBTTerms = YES
 proselint.GenderBias = YES
+

--- a/_includes/sections/work-we-do/building-services.md
+++ b/_includes/sections/work-we-do/building-services.md
@@ -89,7 +89,7 @@ iterate them based on feedback. We also use the alpha phase to carry out
 technical spikes and experiments, and to make initial technology and service
 design decisions.
 
-**Beta**: Build a working version of the service, based on what we learnt in
+**Beta**: Build a working version of the service, based on what we learned in
 alpha. Carry out regular usability testing of the service with users, and launch
 a minimum viable product. Make plans for supporting the service and continue
 iterating it.

--- a/_includes/sections/working-here/hiring-new-people.md
+++ b/_includes/sections/working-here/hiring-new-people.md
@@ -149,7 +149,7 @@ the first hour of the work day.
 
 #### Work day
 
-TODO. This section to cover:
+To be added. This section to cover:
 
 - Principles for a good work day
 - Preparing a work day activity
@@ -161,7 +161,7 @@ TODO. This section to cover:
 
 #### Offer, joining and probation
 
-TODO. This section to cover:
+To be added. This section to cover:
 
 - Salary negotiation, notice periods and start date
 - Eligibility to work in the UK, documentation that we need

--- a/_includes/sections/working-here/hiring-new-people.md
+++ b/_includes/sections/working-here/hiring-new-people.md
@@ -26,7 +26,7 @@ skills are a good fit for the job. A good job description has three parts:
    good at their job
 
 There are lots of job descriptions on the website if you need inspiration. It's
-important for them to be declarative ("The person with this job will...") and as
+important for them to be declarative ("The person with this job will…") and as
 objective as possible. Throughout the rest of the process, we'll use this
 document to decide what questions to ask in interviews, and to fix activities
 for the work day. The skills and personal qualities need to be things that we
@@ -168,7 +168,7 @@ TODO. This section to cover:
 - Background check
 - Starters checklist
 - The probation period, meeting and expectations
-- ...more things.
+- …more things.
 
 #### Returners' programme
 

--- a/guides/being-a-tech-lead-at-dxw.md
+++ b/guides/being-a-tech-lead-at-dxw.md
@@ -2,9 +2,9 @@
 title: Being a tech lead at dxw
 ---
 
-## Being a tech lead...
+## Being a tech lead…
 
-### ...at an agency
+### …at an agency
 
 Our work with a client is always temporary. Sometimes we know the end before we
 start, and sometimes it seems like it will go on forever. But eventually the
@@ -73,7 +73,7 @@ risk they're prepared to carry. We often have to do some amount of mediation in
 that case (usually biased towards delivery - it's what we're there for after
 all).
 
-### ...for public services
+### …for public services
 
 The public sector has a history of abdicating digital and technology decisions
 to suppliers. That's caused a loss of the expertise needed even to make sound
@@ -102,7 +102,7 @@ short tenure for those technologists they do manage to hire. But it also means
 you'll often be working with folks who are motivated more by doing public good
 than they are by chasing money.
 
-### ...at the intersection of the two
+### …at the intersection of the two
 
 When building a public service, it can be hard to ever call it done. Especially
 when much of your team's time is spent dealing with broken foundations (lack of

--- a/guides/plugin-advisories.md
+++ b/guides/plugin-advisories.md
@@ -65,7 +65,7 @@ Description:
 or maybe:
 
 > If an attacker is able to convince a logged-in admin user to follow a link
-> (phishing emails can be made to look very convincing), then ...
+> (phishing emails can be made to look very convincing), then …
 
 Proof of concept:
 
@@ -83,7 +83,7 @@ server
 Description:
 
 If there are classes with methods like `__destruct()` that have certain
-properties, the attacker can ...
+properties, the attacker can …
 
 ### Mitigations
 

--- a/guides/service-design-at-dxw.md
+++ b/guides/service-design-at-dxw.md
@@ -126,7 +126,7 @@ experience of applying service design to projects at dxw.
   with the technology and processes that surround them. Service designers help
   manage these **technical and non-technical interfaces**.
 
-## 7. Beta, live and beyond...
+## 7. Beta, live and beyond…
 
 - Service designers like to be involved throughout the beta and live phases of a
   new service to help ensure that **performance is tracked and outcomes


### PR DESCRIPTION
Various fixes and linter adjustments to get the prose linting tests passing on the playbook.

- Do not use the dxw style on `tone-of-voice.md`, as this file contains deliberate mistakes to show what not to do
- Reduce write-good.ThereIs and write-good.So to warnings. These are grammatical undesirables but we use them a lot in the playbook
- Replace instances of '...' with the appropriate symbol. I did not want to change proselint.Typography to a warning, because this checker could pick up other more important errors down the line
- Reduce proselint.Cliches to a warning, we do use a few cliches but I think they are appropriate for our tone/content
- Reduce proselint.DateSpacing and proselint.DateCase to a suggestion, because our date formatting is fine for the playbook
- Reduce proselint.Skunked, proselint.Very and proselint.But to suggestions. These aren't errors in write-good, so this brings both linters in line with each other
- Reduce proselint.RASSyndrome to a warning. Acronyms that repeat themselves (e.g. "ATM Machine") are incorrect but also widely understood
- Change two instances of "TODO" to the more natural "To be added".