### PR TITLE
Rename to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:

--- a/guides/contributing.md
+++ b/guides/contributing.md
@@ -109,5 +109,5 @@ requests.
    green `Merge pull request` button on the `Conversation` tab.
 
 The Playbook is hosted on [GitHub Pages](https://pages.github.com), and it's
-tracking the `master` branch. This means changes will be published automatically
+tracking the `main` branch. This means changes will be published automatically
 when a pull request is merged.


### PR DESCRIPTION
Update workflow and contributing guide to use `main` as the name of the main branch.

Presumably renaming the branch should happen roughly in the same time?