### PR TITLE
Bust gem cache in CI deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,9 @@ jobs:
         uses: actions/cache@v2.1.4
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-gems-v2-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gems-
+            ${{ runner.os }}-gems-v2-
 
       - name: Cache Node dependencies
         uses: actions/cache@v2.1.4


### PR DESCRIPTION
When running the test Github action we were seeing:

```
==> Building Jekyll Site...
bundler: failed to load command: jekyll (/home/runner/work/playbook/playbook/vendor/bundle/ruby/2.7.0/bin/jekyll)
LoadError: libffi.so.6: cannot open shared object file: No such file or directory - /home/runner/work/playbook/playbook/vendor/bundle/ruby/2.7.0/gems/ffi-1.13.1/lib/ffi_c.so
```
Looking at ffi/ffi#881 it seems a new version of ubuntu
was released that did not work with ffi, but was later fixed. We need to bust
our cached gems to fix this.

This PR is identical to https://github.com/dxw/playbook/pull/653 only we need to
replicate the fix in deploy.yml