### PR TITLE
Don't autocommit fixes on PRs from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
 
       - uses: stefanzweifel/git-auto-commit-action@v4.8.0
         if:
+          github.event.pull_request.head.repo.full_name == github.repository &&
           failure() && github.event_name == 'pull_request' &&
           steps.cibuild.outcome == 'failure'
         with:


### PR DESCRIPTION
When a PR is opened from a fork (most commonly from Dependabot) any secrets
in the main git repo will not be available to the forked branch.

See https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

Unfortunately this means this `test` Github action will always fail on Dependabot PRs because it tries to
autocommit fixes, and the secret required to autocommit fixes is not available
to the fork.

We don't think any PRs from Dependabot will require autocommitted linting fixes,
so it is safe to skip this action for PRs opened from forks.