### PR TITLE
Experimental: vale settings for linting only modified files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,6 @@ jobs:
 
       - uses: errata-ai/vale-action@master
         with:
-          onlyAnnotateModifiedLines: true
           styles: |
             https://github.com/errata-ai/proselint/releases/latest/download/proselint.zip
             https://github.com/errata-ai/write-good/releases/latest/download/write-good.zip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: errata-ai/vale-action@master
         with:
-          files: __onlyModified
+          onlyAnnotateModifiedLines: true
           styles: |
             https://github.com/errata-ai/proselint/releases/latest/download/proselint.zip
             https://github.com/errata-ai/write-good/releases/latest/download/write-good.zip

--- a/_includes/sections/working-here/your-pay-pension-and-other-benefits.md
+++ b/_includes/sections/working-here/your-pay-pension-and-other-benefits.md
@@ -142,12 +142,34 @@ line manager will invite you to an absence meeting to discuss your health. Where
 appropriate, we’ll talk about how we can support your return to work and any
 temporary or permanent adjustments which might help improve your wellbeing and
 support you to need fewer absences. We might also agree an action plan and / or
-a review period. Where we think it would be helpful, we’ll seek medical advice
+a review period. Where we think it would be helpful, we’ll seek advice
 via an Occupational Health advisor.
 
 If you have a long term health condition and would like to discuss reasonable
 adjustments and ways of working that will help, we welcome a conversation at any
 point. The sooner we know, the sooner we can support you.
+
+##### Reasonable Adjustments
+
+A reasonable adjustment is “a change to remove or reduce the effect of an employees’ 
+disability or long term health condition so they can do their job”. If you would like 
+to discuss ways of working and reasonable adjustments that will help you, please talk 
+to your line manager or the people manager at any point. The sooner we know, the sooner we can support you. 
+We will never use the disclosure of a disability or long term health condition against you.
+
+We’ll organise a meeting (or a series of meetings if needed) between you, your line manager, 
+and the people manager where we will discuss any difficulties you are facing and how dxw are 
+able to support you. If there is any additional support we can reasonably give you, for example 
+changes to your working pattern or working environment, we will. We need to balance dxw’s 
+financial sustainability and the unavoidable impact of any adjustments made on your teams with 
+your needs to make sure we are able to give fair and consistent treatment to everyone in need of adjustments, 
+but we will make every effort to make working at dxw as healthy and sustainable for you as we can.
+
+If you need further support, in addition to any support we are able to provide you as an employer 
+and through occupational health, there may be state provided benefits that apply to you. 
+These may include [disability and sickness benefits](https://www.gov.uk/financial-help-disabled/disability-and-sickness-benefits) 
+or the [Access to Work scheme](https://www.gov.uk/access-to-work). If you would like support finding, understanding, 
+or applying for alternatives outside of dxw please discuss this with your line manager or our people manager.
 
 ##### Pay
 

--- a/_includes/sections/working-here/your-pay-pension-and-other-benefits.md
+++ b/_includes/sections/working-here/your-pay-pension-and-other-benefits.md
@@ -142,8 +142,8 @@ line manager will invite you to an absence meeting to discuss your health. Where
 appropriate, we’ll talk about how we can support your return to work and any
 temporary or permanent adjustments which might help improve your wellbeing and
 support you to need fewer absences. We might also agree an action plan and / or
-a review period. Where we think it would be helpful, we’ll seek advice
-via an Occupational Health advisor.
+a review period. Where we think it would be helpful, we’ll seek advice via an
+Occupational Health advisor.
 
 If you have a long term health condition and would like to discuss reasonable
 adjustments and ways of working that will help, we welcome a conversation at any
@@ -151,25 +151,30 @@ point. The sooner we know, the sooner we can support you.
 
 ##### Reasonable Adjustments
 
-A reasonable adjustment is “a change to remove or reduce the effect of an employees’ 
-disability or long term health condition so they can do their job”. If you would like 
-to discuss ways of working and reasonable adjustments that will help you, please talk 
-to your line manager or the people manager at any point. The sooner we know, the sooner we can support you. 
-We will never use the disclosure of a disability or long term health condition against you.
+A reasonable adjustment is “a change to remove or reduce the effect of an
+employees’ disability or long term health condition so they can do their job”.
+If you would like to discuss ways of working and reasonable adjustments that
+will help you, please talk to your line manager or the people manager at any
+point. The sooner we know, the sooner we can support you. We will never use the
+disclosure of a disability or long term health condition against you.
 
-We’ll organise a meeting (or a series of meetings if needed) between you, your line manager, 
-and the people manager where we will discuss any difficulties you are facing and how dxw are 
-able to support you. If there is any additional support we can reasonably give you, for example 
-changes to your working pattern or working environment, we will. We need to balance dxw’s 
-financial sustainability and the unavoidable impact of any adjustments made on your teams with 
-your needs to make sure we are able to give fair and consistent treatment to everyone in need of adjustments, 
-but we will make every effort to make working at dxw as healthy and sustainable for you as we can.
+We’ll organise a meeting (or a series of meetings if needed) between you, your
+line manager, and the people manager where we will discuss any difficulties you
+are facing and how dxw are able to support you. If there is any additional
+support we can reasonably give you, for example changes to your working pattern
+or working environment, we will. We need to balance dxw’s financial
+sustainability and the unavoidable impact of any adjustments made on your teams
+with your needs to make sure we are able to give fair and consistent treatment
+to everyone in need of adjustments, but we will make every effort to make
+working at dxw as healthy and sustainable for you as we can.
 
-If you need further support, in addition to any support we are able to provide you as an employer 
-and through occupational health, there may be state provided benefits that apply to you. 
-These may include [disability and sickness benefits](https://www.gov.uk/financial-help-disabled/disability-and-sickness-benefits) 
-or the [Access to Work scheme](https://www.gov.uk/access-to-work). If you would like support finding, understanding, 
-or applying for alternatives outside of dxw please discuss this with your line manager or our people manager.
+If you need further support, in addition to any support we are able to provide
+you as an employer and through occupational health, there may be state provided
+benefits that apply to you. These may include
+[disability and sickness benefits](https://www.gov.uk/financial-help-disabled/disability-and-sickness-benefits)
+or the [Access to Work scheme](https://www.gov.uk/access-to-work). If you would
+like support finding, understanding, or applying for alternatives outside of dxw
+please discuss this with your line manager or our people manager.
 
 ##### Pay
 


### PR DESCRIPTION
**NOT TO BE MERGED, JUST A TEST**

Experimental: are we getting stuck on 'only modified'?

I'm wondering whether in the case of a PR which contains no
lintable changes, Vale hangs because it's waiting to hear
back from its 2 linters?

Perhaps this `onlyAnnotateModifiedLines` option is an
alternative if our intention is to limit feedback to the
content in the current PR?

i.e. everything will be linted on every PR but warnings and
errors will only be reported where they relate to changes in
the current PR.

Ref: https://github.com/dxw/playbook/pull/583/files