### PR TITLE
Prevent Vale check from hanging when PR contains no markdown changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: touch README.md
 
       - uses: errata-ai/vale-action@master
         with:


### PR DESCRIPTION
Currently, the [Vale action](https://github.com/errata-ai/vale-actionl) hangs when it has no files to lint (e.g. Dependabot generated PRs). This results in the check failing.

I attempted to use a `changed-files` action to only run the Vale check when certain file types were modified in a pull request, but that meant the required `Vale` check never ran at all.

The solution appears to be touching the file (I've used `README.md`) during code checkout.

**NB: This requires `README.md` to pass the linting checks, but this seems reasonable.**