### PR TITLE
(FIX CI) Prose/Vale does not lint third-party markdown files (which fails with errors)

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -4,7 +4,7 @@ MinAlertLevel = warning # suggestion, warning or error
 [guides/tone-of-voice.md]
 BasedOnStyles = Govuk, proselint, write-good
 
-[*.md]
+[guides/*.md]
 BasedOnStyles = dxw, Govuk, proselint, write-good
 
 # Style.Rule = {YES, NO, suggestion, warning, error} to


### PR DESCRIPTION
Before this change, running `npm run lint:prose` would return the following: `✖ 53 errors, 2984 warnings and 0 suggestions in 168 files.`. There is vast output as Vale is scanning every third party vendor, which all include a README.md amougst other documentation.

We only want to see problems with the content we are writing.

This change makes Vale scan every mardown file within the `guides` directory. This doesn't include our README but as a readme I don't think the quality of language we use in that file changes from any other project.

After this change we get the follownig return: `✖ 0 errors, 818 warnings and 0 suggestions in 34 files.`