### PR TITLE
Vale tests all playbook files rather than just guides

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -4,7 +4,7 @@ MinAlertLevel = warning # suggestion, warning or error
 [guides/tone-of-voice.md]
 BasedOnStyles = Govuk, proselint, write-good
 
-[guides/*.md]
+[*.md]
 BasedOnStyles = dxw, Govuk, proselint, write-good
 
 # Style.Rule = {YES, NO, suggestion, warning, error} to

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "npm run lint:prose && npm run format:fix && npm run lint:js:fix && npm run lint:ruby:fix && npm run lint:shell",
     "lint:js": "eslint .",
     "lint:js:fix": "npm run lint:js -- --fix",
-    "lint:prose": "vale .",
+    "lint:prose": "vale index.md _includes/* guides/*",
     "lint:prose:suggestions": "npm run lint:prose -- --minAlertLevel suggestion",
     "lint:ruby": "bundle exec standardrb",
     "lint:ruby:fix": "npm run lint:ruby -- --fix",


### PR DESCRIPTION
I missed the directory within _includes and wrongly assumed all the content was in the guides directory in this earlier fix to CI [1]. This change runs vale on the index.md and _includes directory.

I couldn't see how to provide multiple paths to the same Vale configuration block so I decided to leave that as * and instead be specific about the directory when we invoke vale in the test file.

[1] https://github.com/dxw/playbook/pull/740