### PR TITLE
Guidance for line managers in supporting L&D

### DIFF
--- a/_includes/sections/working-here/supporting-your-development-and-wellbeing.md
+++ b/_includes/sections/working-here/supporting-your-development-and-wellbeing.md
@@ -165,6 +165,8 @@ Everybody at dxw gets a yearly learning and development allowance.
 Read the [Learning and Development guide](/guides/learning-and-development) to
 find out more.
 
+Read the [line managers guide](/guides/line-management-guides) to learn about how to support Learning and Development for your team members/
+
 #### Private Slack channels
 
 We encourage everyone at dxw to be open about their identities and the

--- a/guides/line-management-guides.md
+++ b/guides/line-management-guides.md
@@ -1,0 +1,22 @@
+---
+title: Guides for Line Managers
+---
+
+## Learning and development for your team members
+
+Part of your work will be to help your team members grow and develop.
+
+Periodically you should check in with people to set and review their goals and objectives. When talking about their plans for growth, have a discussion about training and possible ways to improve or gain new skills. When you agree on those, help them find opportunities or training to reach them.
+
+As and example these are the areas to cover in learning and development plan:
+
+- Current role
+- Future or changing role
+- Personal development, health and wellbeing
+- Long term career development
+
+For each of those you could set a short description of the aims, set priority, work out how to achieve it and measure progress.
+
+Keep an eye on and proactively help people think about their L&D allowance. It’s also important to communicate and help team members to make space for using L&D.
+
+Regular conversations with the Head of Practice or a Director focused on teams L&D to help keep track of the progress and proactively looking for ways and opportunities to provide people space and time to develop.


### PR DESCRIPTION
This is the start for helping people set their learning and development objectives with their line managers and how to measure progress.

This is mostly to embed L&D conversations as a part of 1:1 meetings and distributing the responsibility to line managers a bit more to help grow people.