### PR TITLE
Add linting back to Husky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,3 @@ npm-debug.log
 /_site/
 /dist/
 /tmp/
-
-/.husky

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run lint


### PR DESCRIPTION
This was removed in https://github.com/dxw/playbook/pull/806 when we updated Husky to 7.0.0 to fix a security vulnerability.

I've confirmed this is working now, as it runs when I commit.