### PR TITLE
Fix headings being covered when using anchor links

### DIFF
--- a/_javascript/lib/sidebarNavigation.js
+++ b/_javascript/lib/sidebarNavigation.js
@@ -4,8 +4,7 @@ export default (links) => {
   };
 
   const getElementLocation = (element) => {
-    const navElement = document.querySelector(".app-nav");
-    const yOffset = navElement.offsetHeight;
+    const yOffset = parseInt(getComputedStyle(element).scrollMarginTop) || 0;
 
     return element.getBoundingClientRect().top + window.pageYOffset - yOffset;
   };

--- a/_spec/javascript/lib/sidebarNavigation.test.js
+++ b/_spec/javascript/lib/sidebarNavigation.test.js
@@ -15,8 +15,8 @@ describe("sidebarNavigation", () => {
       <nav class="app-nav"></nav>
       <a href="#bar" data-target="bar" class="active"></a>
       <a href="#foo" data-target="foo"></a>
-      <div id="foo"></div>
-      <div id="bar"></div>
+      <h2 id="foo"></h2>
+      <h2 id="bar"></h2>
     `;
 
     links = document.querySelectorAll("a");

--- a/_stylesheets/styles.scss
+++ b/_stylesheets/styles.scss
@@ -39,6 +39,7 @@ h6 {
   font-family: Poppins, sans-serif;
   font-weight: 600;
   color: $navy;
+  scroll-margin-top: 80px;
 }
 
 b,


### PR DESCRIPTION
Because we have a sticky header nav, we need to provide an offset when jumping to heading using an anchor link so that that the header doesn't cover the heading.

We had that offset in our JS, but not in our CSS. That meant that if you follow a link from outside the Playbook, the heading would be covered.

This change adds a `scroll-margin-top` property in the CSS to correct this, and changes the JS to use that value so that they are always the same.

The downside is that the offset is no longer linked to the size of the header, so if it got taller, this hardcoded number would also need to change.