### PR TITLE
Document technology team progression and promotion

### DIFF
--- a/_includes/sections/our-professions/development.md
+++ b/_includes/sections/our-professions/development.md
@@ -129,7 +129,7 @@
    Where you can, do less and deliver it sooner. Break down work into smaller
    pieces. Descope anything that isn’t critical for a first version. Do a
    minimum slice that works for some of your users. Anything to reduce the time
-   between get started on something and delivering it to users.
+   between getting started on something and delivering it to users.
 
    Work at a pace that suits the project. Hacky is sometimes fine. If you’re
    working on prototypes then do only what you need to answer your questions.
@@ -150,3 +150,22 @@
    communicating about our work allows clients to see how we’re doing, and what
    needs their attention, and gives everyone in the team context for the work
    being done and decisions being made.
+
+#### Career progression for developers
+
+We have a
+[public progression framework](https://dxw.progressionapp.com/technology)
+describing the skills expected of each role across the technology team. Your
+progression doesn’t depend on having done everything in the framework for the
+new role but on demonstrating that you could do them if asked.
+
+We track changes to the framework in the
+[changelog](https://docs.google.com/document/d/1FZc0Tr7RizgdGSs2MRD8USs372kUK8yqZ8kIlRf6zQc/edit),
+where we describe what changed and why we changed it. We keep track of any
+future changes we may want to make or think about in the
+[backlog](https://docs.google.com/document/d/16pZuxt_CWp2NFaYaqBIZvuHmPeNWcqKycLkx5ciErbw/edit).
+
+We have a [documented promotion process](/guides/tech-team-promotion-process)
+based on that framework. We designed it to help make fair decisions about
+promotions that reduce the impact any one person can have on the decision as
+much as possible.

--- a/guides/tech-team-promotion-process.md
+++ b/guides/tech-team-promotion-process.md
@@ -1,0 +1,360 @@
+---
+title: Technology team promotion process
+---
+
+This policy applies to ad-hoc promotions for roles corresponding to SFIA 1-5
+only. For gaps we identify in the team, one-off roles, or more senior roles
+(SFIA 6-7), we use a different process, often involving internal or external
+recruitment.
+
+The process is based on
+[our progression framework](https://dxw.progressionapp.com/technology) and
+designed to help make fair decisions about promotions that reduce the impact any
+one person can have on the decision as much as possible. You will be promoted if
+a panel from across dxw and your Head of Discipline agree you are currently able
+or will soon be able to do the activities described by the framework for the
+role you are moving into.
+
+Are you here as a panelist? [Skip ahead to the section for you!](#for-panelists)
+
+## For applicants
+
+### Summary
+
+1. You express an interest in being promoted
+1. The directors decide if there is scope for accepting promotions of that kind
+   from a business perspective
+1. An application deadline is set
+1. You gather evidence into a promotion pack (supported by your line manager)
+1. You submit the promotion pack for review by a promotion panel
+1. Panelists review your pack independently
+1. The panel meets to discuss your application and make a strong recommendation
+   on whether to approve it or not
+1. A decision is made
+1. The decision is shared with you with feedback
+
+### Eligibility
+
+Anyone can apply for a promotion at any time, provided you have completed
+probation. While it’s helpful and strongly recommended, you do not need your
+line manager’s agreement.
+
+There is no limit to the frequency of promotions you are allowed to apply for.
+
+### Expression of interest
+
+You can express your interest in going up for promotion by talking to your line
+manager and Head of Discipline. Do this before you start preparing your
+application.
+
+Your Head of Discipline then considers your readiness for promotion based on
+their current information and a conversation with your line manager, so they can
+help set expectations with you for the result, but they are not allowed to
+prevent you from applying.
+
+### Directors’ review
+
+Your Head of Discipline works with the directors to decide if there is scope for
+a role change of this kind. The task here is to consider the business
+implications of a possible promotion, not to decide whether or not you deserve
+the promotion. They consider things like the cost and team structure
+implications and make a decision about whether or not to accept applications.
+
+Possible decisions are:
+
+- Promotions would be accepted, with immediate effect
+- Promotions would be accepted, but at a future specified date
+- Promotions would not be accepted, but may become available within the next
+  year
+- Promotions would not be accepted, and are unlikely to become available within
+  the next year
+
+If promotions would be accepted, they also decide on an upper limit on the
+number of promotions to that role that could be accommodated.
+
+The Head of Discipline and directors must make their decision **within 4 weeks
+of the request being raised with them**.
+
+### Opening applications
+
+Once the directors have made a decision, your Head of Discipline lets you and
+your line manager know what it is.
+
+Your Head of Discipline sets a **deadline for applications to be submitted by,
+between 4 weeks and 8 weeks after the date of the directors’ decision** to give
+you time to prepare your promotion pack.
+
+If the decision is that promotions are possible, but there is only one position
+available, your Head of Discipline informs anyone else eligible for a promotion
+to the same role and invites them to apply for the position. For this, a person
+is notified if they are currently at the level below in the discipline.
+
+### Creating the promotion pack
+
+You put together a promotion pack from one of
+[the templates](https://drive.google.com/drive/folders/1q4idxObiYhqOAWuzudFQcGAk_70yZk-I)
+explaining why you feel you are ready for a promotion. This pack includes a
+short personal statement on why you feel you should receive a promotion, a
+statement from your line manager on the same topic, and evidence to demonstrate
+why you would meet the needs of the role you would be promoted into. Good
+evidence for this might include:
+
+- evidence of you doing the things described with how they went
+- feedback from people you have worked with or clients that demonstrate your
+  ability to do the things described
+- evidence of similar activities that give you and your line manager confidence
+  you are ready to take on the responsibilities of the role
+
+Make sure you address all of the needs of the level and don’t leave any gaps.
+It’s ok to acknowledge that you don’t have direct experience of something in the
+framework. It’s better to do that than have the panel spend time working out if
+you do or not and run out of time to properly consider your strengths.
+
+You should involve your line manager in the process, but they are not allowed to
+block your promotion. They should support you with developing your promotion
+pack, but you can put yourself forwards for promotion without your line
+manager’s support.
+
+If you are reading this thinking about a future promotion, you might want to
+consider keeping a [brag document](https://jvns.ca/blog/brag-documents/) or
+using the Wins feature of Progression to keep track of evidence you might want
+to use in the future.
+
+### Submitting the application
+
+Email a link to your promotion pack to a member of the HR team, your Head of
+Discipline and your line manager. You need to also transfer ownership of any
+documents to a member of the HR team so it can go into your file and make sure
+your Head of Discipline has access to modify sharing settings so they can share
+it with panelists.
+
+While optional, it’s recommended that you share the pack with your Head of
+Discipline at least a week in advance of the application deadline so they can do
+a pre-check and make suggestions based on their experience reviewing other
+promotions, such as places where you could provide more detail.
+
+### Promotion panel
+
+While you create your promotion pack, your Head of Discipline decides on an
+appropriate panel to review your application.
+
+A panel is made up of:
+
+- someone from your discipline at least as senior as the role you are applying
+  for, if possible
+- your Head of Discipline (unless they are your line manager)
+- another member of the technology leadership team (Head of Development, Head of
+  Technical Operations, and Technical Architects)
+- two Heads of Discipline, Principals, or Leads from outside the technology team
+
+The panel must not include your line manager, buddy, or anyone in a close
+personal relationship with you to avoid conflicts of interest. This includes
+people who would consider you a friend as well as a colleague.
+
+Your Head of Discipline appoints one member of the panel (not necessarily the
+most senior person and not your Head of Discipline) as the lead. It is their
+responsibility to organize the review process, run the joint panel, and make
+sure your application is properly considered.
+
+Your promotion panel must meet **between 1 and 2 weeks after the application
+deadline** to be able to give you a timely decision and response while also
+considering your application properly.
+
+If there is more than one applicant for a single promotion opportunity, the
+panel must be different for each applicant. Some overlap between panels is ok if
+necessary, but should be avoided if possible.
+
+### Review process
+
+#### Independent review
+
+**At least 1 week before the panel meets**, the lead panelist creates a review
+form from
+[a template](https://drive.google.com/drive/folders/1q4idxObiYhqOAWuzudFQcGAk_70yZk-I),
+transfers ownership of it to a member of the HR team for filing, and sends it
+with your promotion pack to each member of the panel.
+
+The panelists then individually review the application without conferring with
+each other and score against each of the criteria in the progression framework.
+They use a scale of 1 to 5 where:
+
+- 1 means you have a lot to improve before being able to work at the level you
+  are applying for
+- 3 means you are working at or are capable of working at the level you are
+  applying for
+- 5 means you are already working at or are capable of working at a level more
+  senior level than the one you are applying for
+
+Each score given must be accompanied by a few lines of reasoning. This helps
+make sure the scores can be reviewed for objectivity. The average of all of your
+scores for each criteria are shared with you as part of your feedback, but not
+individual scores or their reasoning verbatim to enable panelists to be open and
+honest.
+
+A panel member can choose to abstain from scoring a specific criteria if they
+believe they are unable to evaluate it due to a lack of their own expertise.
+
+Panelists should set aside 2 hours to do this for each candidate they are
+reviewing.
+
+**Individual panelists must complete the form at least 24 hours before they are
+due to meet.**
+
+The panel meeting may be pushed back or an alternative panelist may be found if
+collecting all of their scores by this deadline is impossible due to unexpected
+absence.
+
+#### Joint review
+
+The full panel meets to discuss the application in the afternoon (to allow for
+chasing any late submitters) **between 1 and 2 weeks after the application
+deadline**. The purpose of the meeting is for the panel to make a strong
+recommendation to your Head of Discipline on whether or not to accept your
+application.
+
+The panel meeting should not last more than 1 hour for a single candidate.
+
+During the meeting, one of the panelists documents the discussion and any new
+scores to be shared at the end with your Head of Discipline.
+
+### Decision
+
+Your Head of Discipline considers the panel’s recommendation along with the
+wider business context. They can choose to override the recommendation, but if
+they do, they must explain and justify that decision to the panel. If panelist
+believes it to be insufficient justification, they should inform the directors
+who make the final decision.
+
+### Feedback
+
+Whether your application is approved or rejected, your Head of Discipline
+delivers written feedback at the end of the process. That feedback is based on
+the discussions in the promotion panel and the independent reviews, and includes
+the average scores from the individual scoring as well as the final scores
+decided by the joint panel including where they could not agree.
+
+Your Head of Discipline shares this feedback with you, your line manager, the
+panelists and the HR team.
+
+### Appeals
+
+If you believe you have not been treated fairly through this process, you can
+appeal the decision. To appeal a decision, you should raise it in writing to the
+Managing Director, copying in a member of the HR team. They then investigate the
+review process for your application and organize a meeting with you to discuss
+their findings. You may bring a colleague or a trade union representative with
+you to that meeting. After the meeting, the Managing Director makes a final
+decision about any further actions and shares it with you in writing.
+
+## For panelists
+
+### Expectations of panelists
+
+As a panelist, you are taking on a lot of responsibility. Your actions and
+decisions have a material impact on the applicant you are evaluating and have
+potentially far reaching consequences.
+
+This process asks two things of you:
+
+- 1 hour of your time to meet with the rest of the panel to discuss the
+  application
+- 2 hours in the week leading up to that meeting to evaluate the application
+  independently
+
+You should make sure that time is protected and is your highest priority, so you
+give the person you’re deciding the fate of your full attention and
+consideration. If you don’t think you can do that, you should let the panel
+selectors know before accepting the role.
+
+To avoid conflicts of interest, you must also not be the applicant’s line
+manager, buddy, or have a close personal relationship with them, including a
+friendship relationship.
+
+If you agree to be a lead panelist, you also need to facilitate the review
+process. You should expect to spend an additional 1-2 hours organizing and
+preparing for the reviews on top of the time for you to contribute to it.
+
+### Instructions for lead panelists
+
+Once you have accepted the position as lead panelist:
+
+1. Ask the Head of Discipline for the names of the other panelists and the
+   application deadline.
+
+1. Set up an application deadline calendar event at 16:00 on the deadline,
+   inviting the applicant, their line manager, and their Head of Discipline.
+   This is the date by which the applicant must submit their promotion pack by
+   email to a member of the HR team, their Head of Discipline, and their line
+   manager. Include the
+   [instructions on how to submit the application](#submitting-the-application)
+   described in the process above in the event description.
+
+1. Set up a joint review with all of the panelists. This review must be between
+   7 and 14 days after the application deadline. It should be a 1 hour event in
+   the afternoon. You will want to set this up as soon as possible to hold the
+   time for all of the panelists.
+
+1. Set up an independent review deadline calendar event exactly 24 hours before
+   the start of the joint review, inviting all of the panelists.
+
+1. After the application deadline, ask the Head of Discipline to share the
+   promotion pack with you and the other panelists in read-only mode.
+
+1. Create the independent review form from
+   [the appropriate template](https://drive.google.com/drive/folders/1q4idxObiYhqOAWuzudFQcGAk_70yZk-I)
+   and invite the panelists (including yourself) to complete it by the review
+   deadline.
+
+1. Don’t look at any other submissions until you have done your own.
+
+1. Make sure you have received all independent reviews by the deadline
+   (including your own). If you don’t have all the reviews by that time, talk to
+   the Head of Discipline or a director about getting the missing reviews as
+   soon as possible.
+
+1. Prepare a slide deck from
+   [the template](https://docs.google.com/presentation/d/1ZqwIaVkFDXnY7ifGS3Kp3ZQQvvKF0IapPhnbUGDoQZQ/edit),
+   documenting the results of the independent review. It’s useful to include the
+   graphs. You should organize the criteria for discussion in the following
+   order:
+
+   1. Criteria where some scores are 3 or above and some are 2 or below.
+      Prioritize criteria with the highest variance in scores.
+
+   1. Criteria where all of the scores are 2 or below.
+
+   1. Criteria where all of the scores are 3 or above. There is usually no need
+      to discuss these criteria, but start with the ones with the highest
+      variance in scores.
+
+1. Ask one of the other panelists to take notes during the meeting in a document
+   shared with all panelists.
+
+1. Facilitate the joint review discussion, sharing the slide deck you prepared.
+
+   1. The first task is to gather consensus on criteria where panelists
+      disagreed in their independent reviews. Invite panelists to talk about
+      their scores and why they gave them, then discuss the evidence and
+      criteria. When ready to move on, simultaneously vote on new scores and
+      record the individual votes. This will take up the bulk of the time, but
+      be prepared to move the panel on if they seem unable to reach consensus.
+      It’s important for the panel to discuss all of the criteria with
+      disagreement, so plan how long to allow on each one in advance.
+
+   1. The second task is to identify whether or not any criteria now scoring 2
+      or below is sufficient to disqualify the applicant. It’s unusual to
+      approve a promotion for someone with 2 or more criteria in this category.
+      This can be useful to consider if you are struggling to reach consensus on
+      a few criteria with 20 minutes remaining and need something to break the
+      tie.
+
+   1. The third task is to generate a recommendation for whether or not to
+      accept the application for promotion. Simultaneously vote and record the
+      individual votes. Everyone must cast a vote here. There is no abstention.
+      Allow at least 10 minutes at the end for this step.
+
+1. Share the new scores and notes from the session with the Head of Discipline.
+
+1. That’s it. You’re done. Thank you for your help!
+
+Please keep the Head of Discipline informed as you work through this process!


### PR DESCRIPTION
This documents our new promotion process in the tech team along with surfacing the progression framework for developers. Ideally I'd have liked to put the progression framework part in a general "technology team" section, but we don't have one, so I opted for developers for now.