### PR TITLE
Add RFCs to the list of tech lead responsibilities

### DIFF
--- a/guides/being-a-tech-lead-at-dxw.md
+++ b/guides/being-a-tech-lead-at-dxw.md
@@ -151,6 +151,8 @@ A tech lead's job is to:
   development work
 - be responsible for the team learning from failure and for incident reviews
   happening when something goes wrong
+- ensure that the development process and repository follow our
+  [RFCs](https://github.com/dxw/tech-team-rfcs)
 
 You will often, but not always, be the most experienced developer on the team.
 When you are you'll also be expected to make clear and informed architectural


### PR DESCRIPTION
It's the tech lead's responsibility to make sure that RFCs are being followed on a project, but this was not previously documented.