### PR TITLE
Update Guides “managing”

### DIFF
--- a/_guides/managing.md
+++ b/_guides/managing.md
@@ -81,7 +81,7 @@ The owners of each section are:
 * David Mann - [Who we are](/#who-we-are)
 * Alex Jackson - [The work we do > Sales](/#sales)
 * Clare Young - [The work we do > Building services](/#building-services)
-* Alex Farley -
+* Alex Jackson -
   [The work we do > Hosting and supporting services](/#hosting-and-supporting-services)
 * Wendy Coello -
   [The work we do > Sharing our expertise](/#sharing-our-expertise)

--- a/_guides/managing.md
+++ b/_guides/managing.md
@@ -79,9 +79,9 @@ The owner is responsible for making sure that their parts of the Playbook:
 The owners of each section are:
 
 * David Mann - [Who we are](/#who-we-are)
-* Adam Maddison - [The work we do > Sales](/#sales)
+* Alex Jackson - [The work we do > Sales](/#sales)
 * Clare Young - [The work we do > Building services](/#building-services)
-* Dominic Baggott -
+* Alex Farley -
   [The work we do > Hosting and supporting services](/#hosting-and-supporting-services)
 * Wendy Coello -
   [The work we do > Sharing our expertise](/#sharing-our-expertise)


### PR DESCRIPTION
Suggested replacements to manage Playbook sections formerly managed by people who've left dxw.

Automatically generated by Netlify CMS