### PR TITLE
Add scripts for setting up and running the application locally

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew "nodenv"
+brew "rbenv"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,35 @@ The Playbook documents how the Playbook gets changed. See the
 [This Playbook](https://playbook.dxw.com/#this-playbook) section for more
 information.
 
+## Development guide
+
+### Setup
+
+Run the setup command. This installs the dependencies required for running the
+project.
+
+```
+script/setup
+```
+
+To just update dependencies, you can run the bootstrap command (though this
+currently does the same as `script/setup` due to the small number of
+dependencies required):
+
+```
+script/bootstrap
+```
+
+### Running the application
+
+To run the server, from the root directory, run:
+
+```
+script/server
+```
+
+This runs the server on localhost:4000.
+
 ## Licence
 
 The contents of dxw's Playbook is released under a

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# script/bootstrap: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -f Brewfile ] && [ "$(uname -s)" = "Darwin" ]; then
+  set +e
+  echo "==> Installing Apple Command Line tools if required..."
+  xcode-select --install
+  echo "==> Apple Command Line tools installed..."
+  set -e
+  if ! brew bundle check >/dev/null 2>&1; then
+    echo "==> Installing Homebrew dependencies..."
+    brew update
+    brew upgrade ruby-build
+    brew bundle install --verbose --no-lock
+  fi
+fi
+
+if [ -f .ruby-version ]; then
+  eval "$(rbenv init -)"
+
+  if [ -z "$(rbenv version-name 2>/dev/null)" ]; then
+    echo "==> Installing Ruby..."
+    rbenv install --skip-existing
+    rbenv rehash
+  fi
+fi
+
+if [ -z "$(nodenv version-name 2>/dev/null)" ]; then
+  echo "==> Installing Node..."
+  brew upgrade node-build
+  nodenv install
+  nodenv rehash
+fi
+
+echo "==> Installing Ruby dependencies..."
+bundle install
+
+echo "==> Installing JS dependencies..."
+npm install

--- a/script/server
+++ b/script/server
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# script/server: Launch the application and any extra required processes
+#                locally.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+bundle exec jekyll serve

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# script/setup: Set up the application for the first time after cloning, or set
+#               it back to the initial unused state.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Running bootstrap script..."
+script/bootstrap


### PR DESCRIPTION
## Changes in this PR

- Adds Ruby installation tool-agnostic (as not everyone uses the same thing) scripts to rule them all: `script/setup`, `script/bootstrap` and `script/server`.
- Documents how to run the app locally in the README.
