### PR TITLE
Clarify that some advice does not apply to GovPress

### DIFF
--- a/_guides/tech-team-junior-developer-development-plan.md
+++ b/_guides/tech-team-junior-developer-development-plan.md
@@ -1,6 +1,9 @@
 ---
-title: Junior developer development plan
+title: Technology team junior developer development plan
 ---
+
+_Please note that this document does not apply to the GovPress team._
+
 ## High level goals
 
 Before a junior developer can be promoted, they need to be:

--- a/_guides/tech-team-junior-developer-development-plan.md
+++ b/_guides/tech-team-junior-developer-development-plan.md
@@ -1,8 +1,8 @@
 ---
-title: Technology team junior developer development plan
+title: Junior developer development plan (Delivery+)
 ---
 
-_Please note that this document does not apply to the GovPress team._
+**Please note that this guide applies to the Delivery+ team only.**
 
 ## High level goals
 

--- a/_guides/tech-team-promotion-process.md
+++ b/_guides/tech-team-promotion-process.md
@@ -6,6 +6,8 @@ only. For gaps we identify in the team, one-off roles, or more senior roles
 (SFIA 6-7), we use a different process, often involving internal or external
 recruitment.
 
+_Please note that this document does not apply to the GovPress team._
+
 The process is based on
 [our progression framework](https://dxw.progressionapp.com/technology) and
 designed to help make fair decisions about promotions that reduce the impact any

--- a/_guides/tech-team-promotion-process.md
+++ b/_guides/tech-team-promotion-process.md
@@ -6,7 +6,7 @@ only. For gaps we identify in the team, one-off roles, or more senior roles
 (SFIA 6-7), we use a different process, often involving internal or external
 recruitment.
 
-_Please note that this document does not apply to the GovPress team._
+**Please note that this process applies to the Delivery+ team only.**
 
 The process is based on
 [our progression framework](https://dxw.progressionapp.com/technology) and

--- a/index.markdown
+++ b/index.markdown
@@ -3263,7 +3263,9 @@ Designers at dxw follow these principles:
     needs their attention, and gives everyone in the team context for the work
     being done and decisions being made.
 
-#### Career progression for developers
+#### Career progression for developers in the technology team
+
+_Please note that this subsection does not apply to the GovPress team._
 
 We have a
 [public progression framework](https://dxw.progressionapp.com/technology)

--- a/index.markdown
+++ b/index.markdown
@@ -3263,9 +3263,7 @@ Designers at dxw follow these principles:
     needs their attention, and gives everyone in the team context for the work
     being done and decisions being made.
 
-#### Career progression for developers in the technology team
-
-_Please note that this subsection does not apply to the GovPress team._
+#### Career progression for technologists in Delivery+
 
 We have a
 [public progression framework](https://dxw.progressionapp.com/technology)


### PR DESCRIPTION
Some hiring and progression information in both the playbook and the guides only applies to the Technology Team. This commit clarifies that the advice here does not apply to GovPress developers.