### PR TITLE
Update link to wpscan in advisories page

### DIFF
--- a/src/govpress-unit/plugin-advisories.md
+++ b/src/govpress-unit/plugin-advisories.md
@@ -26,7 +26,7 @@ the
 ## Check for existing advisories
 
 Pluginscan includes a report on vulnerabilities, based on the API exposed by the
-[WPScan Vulnerability Database](https://wpvulndb.com/)
+[WPScan Vulnerability Database](https://wpscan.com/)
 
 It's important that we avoid publishing advisories that have already been
 reported by someone else.

--- a/src/govpress-unit/plugin-advisories.md
+++ b/src/govpress-unit/plugin-advisories.md
@@ -25,8 +25,10 @@ the
 
 ## Check for existing advisories
 
-Pluginscan includes a report on vulnerabilities, based on the API exposed by the
-[WPScan Vulnerability Database](https://wpscan.com/)
+[patchstack](https://patchstack.com/database/) provides an annual report on
+WordPress security, generated from a database of existing vulnerabilities,
+which can be searched from their website or
+[via their API](https://patchstack.com/threat-intel-feed/).
 
 It's important that we avoid publishing advisories that have already been
 reported by someone else.


### PR DESCRIPTION
The link to wpvulndb.com now resolves to wpscan, so it seems sensible just to link directly to the new URL.

Fixes #976 