### PR TITLE
Revert sidebar background to cream on large screens

### DIFF
--- a/src/_sass/_related.scss
+++ b/src/_sass/_related.scss
@@ -47,7 +47,7 @@
     max-width: 30vw;
     height: 100%;
     padding: 1.5em 1em;
-    background-color: colours.$accent-b;
+    background-color: colours.$cream;
 
     a {
       margin-bottom: 0.5em;


### PR DESCRIPTION
In the midst of the Great Playbook Restructure of 2022 (officially known as PR #973), our dear benevolent orchestrator F had split the large screen navigation sidebar in two: one column dedicated to pages and another to in-page navigation. In order to visually differentiate the two columns, the left was given the same blue background colour as the top nav, while the right retained the cream of the original single column sidebar design. In consultation with dxw brass, a decision was made to do away with the in-page navigation altogether, but the remaining page navigation remained blue, da ba dee da ba di

The original cream sidebar provided greater visual differentiation from the top nav, and contributed to a more consistent quadrilateral colour block design, whereas the shared blue background of the sidebar and top nav lead to a six-sided L shape and two quadrilaterals, and a preponderance of blue, da ba dee da ba di

Meanwhile in the Great Playbook Restructure of 2022, the navigation on mobile moved up between the top nav and the main content, and become yellow, per the square in which the D marque sits. This plays nice with the colours in the top nav, and still provides good visual differentiation between the different sections of the page, more so than would a thin bar of cream. This therefore remains unchanged

Closes #978

## Screenshots of UI changes

### Before

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/40244233/194587906-711ee64a-9e53-40da-93c7-97ce811cf9dc.png">

### After

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/40244233/194588096-d3273c97-66e5-4807-979e-86efa5ab168e.png">

### Back in the day

Taken from [Wayback Machine, 26 September](https://web.archive.org/web/20220926082032/https://playbook.dxw.com/#)

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/40244233/194588940-38acbe12-5980-4104-94d1-3fbb5135fe83.png">
