### PR TITLE
FIX 404 errors on admin pages

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -111,16 +111,6 @@ collections:
       - { label: Permalink, name: permalink, widget: hidden, default: /:path/:basename/ }
       - { label: Body, name: body, widget: markdown, required: true }
 
-  - name: finance
-    label: Finance
-    label_singular: Finance page
-    folder: src/finance
-    create: true
-    fields:
-      - { label: Title, name: title, widget: string, required: true }
-      - { label: Permalink, name: permalink, widget: hidden, default: /:path/:basename/ }
-      - { label: Body, name: body, widget: markdown, required: true }
-
   - name: leadership
     label: Leadership
     label_singular: Leadership page

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -1,9 +1,16 @@
-# To run locally, replace the `backend` config with the lines below and run:
-#   cd src && npx netlify-cms-proxy-server
+# To run netlify-cms locally:
+#
+# 1. Replace the `backend` config with the commented configuration below.
+# 2. Remove the `src/` prefix from `file` and `folder` attributes to make them
+#    relative to the site URL, not relative to the repo root (which is needed
+#    by the `github` backend which uses the GitHub API endpoint to find files).
+# 3. On the command line, run:
+#        cd src && npx netlify-cms-proxy-server
 #
 # local_backend: true
 # backend:
 #   name: git-gateway
+#
 backend:
   name: github
   repo: dxw/playbook
@@ -21,7 +28,7 @@ collections:
     files:
       - name: home
         label: Home page
-        file: index.md
+        file: src/index.md
         fields:
           - { label: Title, name: title, widget: string, required: true }
           - { label: Body, name: body, widget: markdown, required: true }
@@ -29,7 +36,7 @@ collections:
   - name: who-we-are
     label: Who we are
     label_singular: Who we are page
-    folder: who-we-are
+    folder: src/who-we-are
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -39,7 +46,7 @@ collections:
   - name: work-we-do
     label: Work we do
     label_singular: Work we do page
-    folder: work-we-do
+    folder: src/work-we-do
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -48,7 +55,7 @@ collections:
   - name: work-we-do__building-services
     label: Work we do > Building services
     label_singular: Building services page
-    folder: work-we-do/building-services
+    folder: src/work-we-do/building-services
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -58,7 +65,7 @@ collections:
   - name: working-here
     label: Working here
     label_singular: Working here page
-    folder: working-here
+    folder: src/working-here
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -67,7 +74,7 @@ collections:
   - name: working-here__getting-things-you-need
     label: Working here > Getting things you need
     label_singular: Getting things you need page
-    folder: working-here/getting-things-you-need
+    folder: src/working-here/getting-things-you-need
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -77,7 +84,7 @@ collections:
   - name: commercial-ops
     label: Commercial Operations
     label_singular: Commercial Operations page
-    folder: commercial-ops
+    folder: src/commercial-ops
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -87,7 +94,7 @@ collections:
   - name: delivery-management
     label: Delivery Management
     label_singular: Delivery Management page
-    folder: delivery-management
+    folder: src/delivery-management
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -97,7 +104,7 @@ collections:
   - name: design
     label: Design
     label_singular: Design page
-    folder: design
+    folder: src/design
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -107,7 +114,7 @@ collections:
   - name: finance
     label: Finance
     label_singular: Finance page
-    folder: finance
+    folder: src/finance
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -117,7 +124,7 @@ collections:
   - name: leadership
     label: Leadership
     label_singular: Leadership page
-    folder: leadership
+    folder: src/leadership
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -127,7 +134,7 @@ collections:
   - name: product-management
     label: Product Management
     label_singular: Product Management page
-    folder: product-management
+    folder: src/product-management
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -137,7 +144,7 @@ collections:
   - name: sales-and-marketing
     label: Sales and Marketing
     label_singular: Sales and Marketing page
-    folder: sales-and-marketing
+    folder: src/sales-and-marketing
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -147,7 +154,7 @@ collections:
   - name: tech
     label: Technology
     label_singular: Technology page
-    folder: tech
+    folder: src/tech
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -157,7 +164,7 @@ collections:
   - name: user-research
     label: User Research
     label_singular: User Research page
-    folder: user-research
+    folder: src/user-research
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -167,7 +174,7 @@ collections:
   - name: govpress-unit
     label: GovPress Unit
     label_singular: GovPress Unit page
-    folder: govpress-unit
+    folder: src/govpress-unit
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }
@@ -177,7 +184,7 @@ collections:
   - name: strategy-unit
     label: Strategy Unit
     label_singular: Strategy Unit page
-    folder: strategy-unit
+    folder: src/strategy-unit
     create: true
     fields:
       - { label: Title, name: title, widget: string, required: true }


### PR DESCRIPTION
Closes #1000

### Notes on testing this PR

To see the admin pages working in the review app, it's probably easiest to go direct to a relevant URL, e.g.: https://deploy-preview-1001--laughing-payne-b9fbd2.netlify.app/admin/#/collections/home

The review app for an unrelated PR can be compared here: https://deploy-preview-998--laughing-payne-b9fbd2.netlify.app/admin/#/collections/home

### Notes on the changes here

When running netlify-cms locally on `main`, this bug could not be reproduced. On production 404 errors are being received from the GitHub API page, e.g. on [this admin page](https://playbook.dxw.com/admin/#/collections/product-management) the console shows a 404 from:

https://api.github.com/repos/dxw/playbook/git/trees/main:product-management

whereas this URL:

https://api.github.com/repos/dxw/playbook/git/trees/main:src/product-management

returns 200 OK. So it seems that the GitHub back-end needs paths relative to the repo root, so that it can correctly query the GitHub API.

The documentation isn't very clear, but this page:

https://www.netlifycms.org/docs/collection-types#file-collections

says:

"""
Each file has its own list of fields and a unique filepath specified in the file field (relative to the base of the repo). 
"""

There isn't an equivalent statement for folder collections.

This PR changes the file paths, and also updates the instructions for running the CMS features locally (where paths can be relative to the content folder).