### PR TITLE
Bump google-protobuf from 3.19.3 to 3.19.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     eventmachine (1.2.7)
     ffi (1.15.4)
     forwardable-extended (2.6.0)
-    google-protobuf (3.19.3)
+    google-protobuf (3.19.6)
     html-proofer (4.4.1)
       addressable (~> 2.3)
       mercenary (~> 0.3)


### PR DESCRIPTION
Dependabot got confused, upgrade manually.