### PR TITLE
Remove search from related pages

### DIFF
--- a/src/_includes/related_pages.html
+++ b/src/_includes/related_pages.html
@@ -1,4 +1,4 @@
-{% assign grouped_related_pages = site.pages | children_of: page | group_by: "related_order" | sort: "name" %}
+{% assign grouped_related_pages = site.pages | children_of: page | where_exp: "child", "child.title != 'Search'" | group_by: "related_order" | sort: "name" %}
 {% for related_page_group in grouped_related_pages %}
   {% assign related_pages = related_page_group.items | sort_natural: "title" %}
 


### PR DESCRIPTION
When on the homepage, the related pages menu on the left included the search page.
This was unintentional - the search page contains no meaningful content without
having initated a search via the box in the top navbar

This removes it from the list of related pages

I tried separating out the filter operation (oⁿ) into an `if` statement, so it
would only run on the homepage. This worked locally, but failed in the Netlify
build with the error below. Perhaps there's a way to do reassignment without
Netlify complaining about unknown tags, but I couldn't find obvious, working
solution from some brief research

```
Liquid Exception: Liquid syntax error (/opt/build/repo/src/_includes/related.html line 3): Unknown tag 'grouped_related_pages' included in /opt/build/repo/src/_layouts/default.html
```

Given the 'related' (child) page count is never more than ~15 and the filter
operation is is very simple, it hopefully doesn't add much burden as is. I
believe it will only run during the build process, since this is Jekyll, so the
excess burden should only be present in the build, not client side