### PR TITLE
Fix CMS cursor

### DIFF
--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -8,6 +8,11 @@
       src="https://identity.netlify.com/v1/netlify-identity-widget.js"
       type="text/javascript"
     ></script>
+    <style>
+      [data-slate-editor] { 
+        -webkit-user-modify: read-write !important;
+      }
+    </style>
   </head>
   <body>
     <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>


### PR DESCRIPTION
When typing anything in the CMS, the cursor immediately moves to the end of the line, making editing using the CMS (without copying and pasting) very difficult

This fix is taken from the GitHub comment below

@see netlify/netlify-cms#5092 (comment)

We could probably put this in a stylesheet, but since it's scoped just to this page/the admin interface, and the file is relatively small and unlikely to grow, it seems okay to include it in the head here as a quick fix

---

The diff and the message above are the same as on the accessibility handbook in the PR linked below. The issue may be isolated to WebKit-powered browsers - I don't see the unwanted behaviour when testing on Firefox without the fix

@see https://github.com/dxw/accessibility-manual/pull/13

## Demo

These are taken from the accessibility handbook PR

### Before

https://user-images.githubusercontent.com/40244233/208674214-7380203e-a68e-496d-a5e1-8b136391eac8.mov

### After

https://user-images.githubusercontent.com/40244233/208674381-4bf5c8cb-8a9d-40dd-9608-87f279b747ff.mov