### PR TITLE
Handle various redirects

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -4,6 +4,8 @@ layout: default
 unrelatable: true
 ---
 
+<script src="/assets/js/redirect.js"></script>
+
 <style type="text/css" media="screen">
   .container {
     margin: 10px auto;

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -17,6 +17,10 @@
       {% if page.title and page.title != "dxw's Playbook" %}{{ page.title | escape }} - {% endif %}Playbook - dxw
     </title>
 
+    {% if page.url == "/" %}
+      <script src="/assets/js/redirect.js"></script>
+    {% endif %}
+
     <link rel="stylesheet" href="/assets/main.css" />
     <script defer data-domain="playbook.dxw.com" src="https://plausible.io/js/plausible.js"></script>
   </head>

--- a/src/_layouts/redirect.html
+++ b/src/_layouts/redirect.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ page.redirect.to }}">
+  <script>location = "{{ page.redirect.to }}" + location.hash</script>
+  <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
+</html>

--- a/src/_layouts/redirect.html
+++ b/src/_layouts/redirect.html
@@ -1,11 +1,35 @@
 <!DOCTYPE html>
-<html lang="en-US">
-  <meta charset="utf-8">
-  <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="{{ page.redirect.to }}">
-  <script>location = "{{ page.redirect.to }}" + location.hash</script>
-  <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
-  <meta name="robots" content="noindex">
-  <h1>Redirecting&hellip;</h1>
-  <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
+<html lang="en-GB">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png">
+    <link rel="manifest" href="/assets/site.webmanifest">
+    <link rel="mask-icon" href="/assets/safari-pinned-tab.svg" color="#5bbad5">
+    <meta name="msapplication-TileColor" content="#243746">
+    <meta name="theme-color" content="#f9f8f5">
+    <title>Redirecting&hellip;</title>
+    <link rel="canonical" href="{{ page.redirect.to }}">
+    <script>location = "{{ page.redirect.to }}" + location.hash</script>
+    <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
+    <meta name="robots" content="noindex">
+
+    <link rel="stylesheet" href="/assets/main.css" />
+    <script defer data-domain="playbook.dxw.com" src="https://plausible.io/js/plausible.js"></script>
+  </head>
+  <body>
+    {% include navbar.html %}
+    <main>
+      {% include related.html %}
+      <article class="page-content">
+        <h1>Redirecting&hellip;</h1>
+        <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
+      </article>
+    </main>
+  </body>
 </html>

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -180,3 +180,19 @@ collections:
       - { label: Title, name: title, widget: string, required: true }
       - { label: Permalink, name: permalink, widget: hidden, default: /:path/:basename/ }
       - { label: Body, name: body, widget: markdown, required: true }
+
+  - name: redirects
+    label: Redirects
+    label_singular: Redirect manager
+    files:
+      - name: redirect-manager
+        label: Redirect manager
+        file: src/redirects.json
+        fields:
+          - label: Redirects
+            name: redirects
+            widget: "list"
+            summary: '{{fields.from}} - {{fields.to}}'
+            fields:
+              - {label: Redirect from, name: from, widget: string, default: "/redirect-from"}
+              - {label: Redirect to, name: to, widget: string, default: "/redirect-to"}

--- a/src/assets/js/redirect.js
+++ b/src/assets/js/redirect.js
@@ -1,12 +1,12 @@
-var fullPath = location.pathname + location.hash
+const fullPath = location.pathname + location.hash
 
 fetch('/redirects.json')
   .then((response) => response.json())
   .then((json) => {
-  var redirectArray = json.redirects
-  var redirectResult = redirectArray.find(item => item.from === fullPath);
+    const redirectArray = json.redirects
+    const redirectResult = redirectArray.find(item => item.from === fullPath)
 
-  if (redirectResult) {
-    location = redirectResult.to
-  }
-});
+    if (redirectResult) {
+      location = redirectResult.to
+    }
+})

--- a/src/assets/js/redirect.js
+++ b/src/assets/js/redirect.js
@@ -1,0 +1,12 @@
+var fullPath = location.pathname + location.hash
+
+fetch('/redirects.json')
+  .then((response) => response.json())
+  .then((json) => {
+  var redirectArray = json.redirects
+  var redirectResult = redirectArray.find(item => item.from === fullPath);
+
+  if (redirectResult) {
+    location = redirectResult.to
+  }
+});

--- a/src/contributing/index.md
+++ b/src/contributing/index.md
@@ -122,3 +122,20 @@ All pages are implicitly sorted by their title unless overridden. To add an
 override, set the value of `related_order` in the frontmatter. A lower number is
 listed before a higher number. Pages without a `related_order` have an implicit
 order value set in `_config.yml` in the root of the project.
+
+### Redirects
+
+There are two approaches to redirects in the playbook and they solve different issues.
+
+#### jekyll-redirect-from gem
+
+A redirect_from entry can be added to a page's front matter - this works for redirecting
+one page to another, and includes keeping the same hash fragment. This is powered by the
+jekyll-redirect-from gem and requires developer assistance. This is the preferred approach
+as it keep redirects tied coupled closely to the content.
+
+#### Redirect manager
+
+There is a redirect manager in the Netlify CMS. Within this admin section you can enter
+a `redirect from` and a `redirect to` value. This currently enables redirecting on some
+pages which do not support the jekyll-redirect-from gem. If you create an entry in this section please test it once the build has completed.

--- a/src/redirects.json
+++ b/src/redirects.json
@@ -1,0 +1,12 @@
+{
+  "redirects": [
+      {
+        "from": "/guides/contributing",
+        "to": "/contributing"
+      },
+      {
+        "from": "/#user-research",
+        "to": "/user-research/"
+      }
+  ]
+}


### PR DESCRIPTION
Adds the redirect.html as an override which is detailed in the [jekyll-redirect-to repo](https://github.com/jekyll/jekyll-redirect-from/blob/master/lib/jekyll-redirect-from/redirect.html). This has then been modified to grab the location hash and append it to the redirect url.

Tested locally using [https://playbook.dxw.com/guides/support-and-on-call.html#claiming-toil-for-out-of-hours-alerts](https://playbook.dxw.com/guides/support-and-on-call.html#claiming-toil-for-out-of-hours-alerts). Not sure if it covers all hash redirect issues but seems to improve some. 

Resolves #1032