### PR TITLE
Add jekyll-sitemap plugin to automatically generate sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "jekyll", "~> 4.2.1"
 group :jekyll_plugins do
   gem "jekyll-redirect-from"
   gem "jekyll-sass-converter", github: 'jekyll/jekyll-sass-converter'
+  gem "jekyll-sitemap"
   gem "nokogiri"
   gem "sass-embedded"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
       terminal-table (~> 2.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.3.1)
@@ -100,6 +102,7 @@ DEPENDENCIES
   jekyll (~> 4.2.1)
   jekyll-redirect-from
   jekyll-sass-converter!
+  jekyll-sitemap
   nokogiri
   sass-embedded
 

--- a/_config.yml
+++ b/_config.yml
@@ -26,3 +26,4 @@ sass:
 
 plugins:
   - jekyll-redirect-from
+  - jekyll-sitemap

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ defaults:
     values:
       layout: default
       related_order: 9999
+url: "https://playbook.dxw.com"
 
 # Build settings
 source: src

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,10 @@ defaults:
     values:
       layout: default
       related_order: 9999
+  - scope: 
+      path: "admin/"
+    values: 
+      sitemap: false
 url: "https://playbook.dxw.com"
 
 # Build settings


### PR DESCRIPTION
Add [`jekyll-sitemap`](https://github.com/jekyll/jekyll-sitemap) to automatically generate a sitemap on build.

Have excluded '/admin' from the sitemap as this does not contain any searchable contents.
The sitemap is currently only listing the `<loc>` tag, as I believe we are not tracking the last modified date. 

Addresses issue #1060 