### PR TITLE
Upgrade packages to fix compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 4.2.1"
+gem "jekyll", "~> 4.3.2"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
@@ -8,7 +8,6 @@ group :jekyll_plugins do
   gem "jekyll-sass-converter", github: 'jekyll/jekyll-sass-converter'
   gem "jekyll-sitemap"
   gem "nokogiri"
-  gem "sass-embedded"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/jekyll/jekyll-sass-converter.git
-  revision: 5d130e8791fc45f60ca7b41c1926b1ee8bf1e279
+  revision: 4468a685657a7ce4fd41f7f6b57262c4bd1c7948
   specs:
-    jekyll-sass-converter (2.1.0)
-      sassc (> 2.0.1, < 3.0)
+    jekyll-sass-converter (3.0.0)
+      sass-embedded (~> 1.54)
 
 GEM
   remote: https://rubygems.org/
@@ -11,7 +11,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.2.0)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -20,7 +20,7 @@ GEM
     eventmachine (1.2.7)
     ffi (1.15.4)
     forwardable-extended (2.6.0)
-    google-protobuf (3.19.6)
+    google-protobuf (3.21.12)
     html-proofer (4.4.1)
       addressable (~> 2.3)
       mercenary (~> 0.3)
@@ -31,35 +31,36 @@ GEM
       yell (~> 2.0)
       zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
-    i18n (1.8.11)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    jekyll (4.2.1)
+    jekyll (4.3.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
-      jekyll-sass-converter (~> 2.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 2.3)
+      kramdown (~> 2.3, >= 2.3.1)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (~> 0.4.0)
+      mercenary (>= 0.3.6, < 0.5)
       pathutil (~> 0.9)
-      rouge (~> 3.0)
+      rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
-      terminal-table (~> 2.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.1)
+    kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.3)
-    listen (3.7.0)
+    liquid (4.0.4)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
@@ -75,21 +76,24 @@ GEM
     public_suffix (4.0.6)
     racc (1.6.1)
     rainbow (3.1.1)
-    rb-fsevent (0.11.0)
+    rake (13.0.6)
+    rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
-    rouge (3.27.0)
+    rouge (4.0.1)
     safe_yaml (1.0.5)
-    sass-embedded (0.11.0)
-      google-protobuf (~> 3.19.0)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    terminal-table (2.0.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
+    sass-embedded (1.58.0)
+      google-protobuf (~> 3.21)
+      rake (>= 10.0.0)
+    sass-embedded (1.58.0-arm64-darwin)
+      google-protobuf (~> 3.21)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    unicode-display_width (1.8.0)
+    unicode-display_width (2.4.2)
+    webrick (1.8.1)
     yell (2.2.2)
     zeitwerk (2.6.0)
 
@@ -99,12 +103,11 @@ PLATFORMS
 
 DEPENDENCIES
   html-proofer
-  jekyll (~> 4.2.1)
+  jekyll
   jekyll-redirect-from
   jekyll-sass-converter!
   jekyll-sitemap
   nokogiri
-  sass-embedded
 
 BUNDLED WITH
    2.3.21

--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,6 @@ url: "https://playbook.dxw.com"
 # Build settings
 source: src
 sass:
-  implementation: sass-embedded
   load_paths:
     - ../node_modules/*
 


### PR DESCRIPTION
As documented in #1056, since the upgrade to Ruby 2.7.7 there has been a gem compatibility issue on (at least my) M2 Air on Ventura 13.1: `sass-embedded` wouldn't install with `bundle`

Ultimately, this upgrades Jekyll (to 4.3.2) and a few other gems

I took the following steps [action: result]:
1. Upgrade `sass-embedded`: `uninitialized constant Sass::Embedded::RenderError`
2. Remove `sass-embedded`: missing dependency
3. Remove `implementation: sass-embedded` from config: server loads; no styles
4. Upgrade `jekyll-sass-converter` to 3 (which uses `sass-embedded` [by default](https://github.com/jekyll/jekyll-sass-converter#dropped-implmentation-option)): incompatible with Jekyll version
5. Upgrade `jekyll`: all works fine

---

Closes #1056