### PR TITLE
Optimise search excerpt to highlight more relevant results

### DIFF
--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -98,13 +98,13 @@
   }
 
   const getExcerpt = (content, searchQuery) => {
-    const searchTerms = searchQuery.split(' ').filter(i => i).map(term => {
-      const regex = new RegExp(term, 'ig')
+    const fullSearchTerm = getTermMatcher(searchQuery, content)
+    const searchTerms = searchQuery
+      .split(' ')
+      .filter((i) => i)
+      .map((term) => getTermMatcher(term, content))
 
-      return { term, regex, matchIndex: content.search(regex) }
-    })
-
-    const firstMatchedTerm = searchTerms.find(term => term.matchIndex !== -1)
+    const firstMatchedTerm = fullSearchTerm.matchIndex !== -1 ? fullSearchTerm : searchTerms.find(term => term.matchIndex !== -1)
     const matchIndex = firstMatchedTerm ? firstMatchedTerm.matchIndex : 100
     const matchLength = firstMatchedTerm?.term.length || 0
     const excerptStartIndex = getStartIndex(matchIndex, content)
@@ -122,6 +122,11 @@
     })
 
     return excerpt
+  }
+
+  const getTermMatcher = (term, content) => {
+    const regex = new RegExp(term, 'ig')
+    return { term, regex, matchIndex: content.search(regex) }
   }
 
   const getStartIndex = (matchIndex, content) => {

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -69,7 +69,7 @@
 
     let innerHtml = ''
 
-    results.forEach((result) => {
+    results.forEach(result => {
       const item = window.store[result.ref]
 
       const breadcrumbs = item.url
@@ -101,8 +101,8 @@
     const fullSearchTerm = getTermMatcher(searchQuery, content)
     const searchTerms = searchQuery
       .split(' ')
-      .filter((i) => i)
-      .map((term) => getTermMatcher(term, content))
+      .filter(i => i)
+      .map(term => getTermMatcher(term, content))
 
     const firstMatchedTerm = fullSearchTerm.matchIndex !== -1 ? fullSearchTerm : searchTerms.find(term => term.matchIndex !== -1)
     const matchIndex = firstMatchedTerm ? firstMatchedTerm.matchIndex : 100


### PR DESCRIPTION
Currently a search result excerpt is generated by searching for the index of each separate term and selecting the first match for the first word (or the first match for the second if it is not found). This means that when selecting the first excerpt from the page it may not be the most relevant to the user as it may contain the first term only when there is a result lower down the page which contains the full term. (Issue #1074 )

This change looks for an excerpt containing the full search term first, so a full match will be prioritised over one containing just one word.

**A few considerations:**
- This doesn't work for special characters. However the search functionality itself does not find words with special characters in the search term (e.g. 'thoughtbot's' will not be found), so we might want to consider ignoring special characters as part of #1030 
- This is only searching for the full search term, and then each separate term in isolation. If, for example, somebody searched with 3 terms it will look for an excerpt containing 3 terms together before falling back on each term in isolation rather than combinations (e.g. the first two terms) - but not sure that doing this will add much value.

Resolves issue #1074 
