### PR TITLE
Add code style checks into CI pipeline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Code style
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+    - uses: actions/checkout@v2
+      name: Check out repository
+    - uses: actions/setup-node@v1
+      name: Set up Node.js
+      with:
+        node-version: 18.13.0
+    - run: |
+        npm ci
+        npm run lint
+      name: Lint
+      

--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ bundle exec jekyll build
 bundle exec htmlproofer _site
 ```
 
+### Code style
+
+[JavaScript Standard Style](https://standardjs.com/) is the authority on style for JavaScript files. This is enforced on pull requests to the main branch. Linting is run across all files as part of the test script.
+
+```
+script/test
+```
+
+Or alternatively you can run standalone linting checks by running
+
+```
+npm run lint
+```
+
 ## Licence
 
 The contents of dxw's Playbook is released under a

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "webpack:dev": "webpack --mode development --watch",
     "webpack:prod": "webpack --mode production",
     "jekyll:dev": "sleep 5 && bundle exec jekyll serve",
-    "jekyll:build": "bundle exec jekyll build"
+    "jekyll:build": "bundle exec jekyll build",
+    "lint": "standard",
+    "lint:fix": "standard --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/script/test
+++ b/script/test
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# script/test: Run test suite for application. Optionally pass in a path to an
+#              individual test file to run a single test.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "Linting files..."
+npm run lint


### PR DESCRIPTION
Related PR: #1082
As there are existing standard lint errors on the repository, these will need to be resolved before merging this PR to prevent any blockers on merging future PRs.

This change adds scripts for linting JavaScript files (Issue #1031 ) using JavaScript Standard Style, and enforces these checks on new pull requests.

- Add new npm script for linting, and include this in a new `script/test` script - which can include future tests and html proofing (#977 ).
- Add new GitHub workflow for runnning lint checks on creating pull requests to `main` branch.
- Add documentation on code style to project README.md
