### PR TITLE
Add code style checks into CI pipeline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Code style
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+    - uses: actions/checkout@v3
+      name: Check out repository
+    - uses: actions/setup-node@v3
+      name: Set up Node.js
+      with:
+        node-version: 18.13.0
+    - run: |
+        npm ci
+        npm run lint

--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ are no broken links. The following are ignored:
 - external links that require authentication, when listed in `lib/utils/check-html`
 - 200 OK status codes - this prevents false positives such as links with anchors
 
+### Code style
+
+This project uses [JavaScript Standard Style](https://standardjs.com/) to enforce consistent style. This is enforced on pull requests to the main branch. Linting is run across all JavaScript files as part of the test script.
+
+```
+script/test
+```
+
+Alternatively you can run standalone linting checks by running `npm run lint`, or fix files using `npm run lint:fix`. Specific files and directories written in the glob pattern can be passed as optional arguments to either script when surrounded by quotes.
+
+E.g.
+```
+npm run lint "src/_webpack/**/*.js"
+```
+
 ## Licence
 
 The contents of dxw's Playbook is released under a

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "webpack:dev": "webpack --mode development --watch",
     "webpack:prod": "webpack --mode production",
     "jekyll:dev": "sleep 5 && bundle exec jekyll serve",
-    "jekyll:build": "bundle exec jekyll build"
+    "jekyll:build": "bundle exec jekyll build",
+    "lint": "standard",
+    "lint:fix": "standard --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/script/test
+++ b/script/test
@@ -13,4 +13,7 @@ fi
 echo "==> Updating..."
 script/update
 
+echo "==> Linting files..."
+npm run lint
+
 script/utils/check-html


### PR DESCRIPTION
This change adds scripts for linting JavaScript files (#1031 ) using JavaScript Standard Style, and enforces these checks on new pull requests.

- Add new npm script for linting, and include this in a new script/test script - which can include future tests and html proofing (#977 ).
- Add new GitHub workflow for runnning lint checks on creating pull requests to main branch.
- Add documentation on code style to project README.md

A PR was opened for this but the build failed after rebasing following an update to the Netlify build config. Subsequent pull requests and merges have resulted in a successful build, and I believe it may be to do with Netlify caching installed gems.

Related PR: #1032 - (which is now merged) resolved any outstanding standard lint errors, with the addition of webpack to allow module imports into JavaScript files.

Resolves issue #1031 