### PR TITLE
Check and fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,11 @@ This runs the server on localhost:4000.
 
 ### Checking the HTML
 
-To proof the HTML for things like dead links, run:
+After making a change, please run `script/test`, which will ensure that there
+are no broken links. The following are ignored:
 
-```
-bundle exec jekyll build
-bundle exec htmlproofer _site
-```
+- external links that require authentication, when listed in `lib/utils/check-html`
+- 200 OK status codes - this prevents false positives such as links with anchors
 
 ## Licence
 

--- a/script/test
+++ b/script/test
@@ -4,4 +4,13 @@
 
 set -e
 
+cd "$(dirname "$0")/.."
+
+if [ -n "$DEBUG" ]; then
+  set -x
+fi
+
+echo "==> Updating..."
+script/update
+
 script/utils/check-html

--- a/script/test
+++ b/script/test
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# script/test: Run the test suite for the application.
+
+set -e
+
+script/utils/check-html

--- a/script/update
+++ b/script/update
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# script/update: Update the application to run for its current checkout.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Bootstrapping..."
+script/bootstrap

--- a/script/utils/check-html
+++ b/script/utils/check-html
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# script/utils/check-html: Validate the HTML built by Jekyll for issues with
+#                          images, links and scripts (including broken links).
+
+#                          This will delete any existing build in `_site`
+#                          and build the site fresh.
+
+#                          This uses htmlproofer and you can pass additional
+#                          htmlproofer arguments like so:
+#                            script/utils/check-html --extra-argument
+
+set -e
+
+# Some URLs containing fragments for highlighting text (for example,
+# https://...#:~:text=Shared%20Parental) or navigating to anchors (including
+# specific slides e.g. https://...#slide=id.g5fe190064c_6_403fail) fail the
+# lint, but return a 200 OK status code. These should not be reported as errors.
+IGNORE_HTTP_STATUS="200"
+
+# Some URLs are authenticated or fail for some other reason that isn't an issue.
+# The syntax comes from the Jekyll codebase:
+#   https://github.com/jekyll/jekyll/blob/master/script/proof
+IGNORE_HREFS=$(ruby -e 'puts %w{
+  expenses.xero.com/!wrUP-/detail/create-new/
+  github.com/dxw/govpress-developer-docs
+  github.com/dxw/judiciary-middleware
+  github.com/dxw/mind-side-by-side
+  mheducation.co.uk/the-good-research-guide-research-methods-for-small-scale-social-research-projects-9780335249831-emea-group
+  twitter.com
+}.map{ |url| "/#{url}/" }.join(",")')
+
+BUILD_PATH="./_site"
+JS_ASSET_PATH="./src/assets/js"
+
+echo "==> Removing any existing build..."
+
+rm -rf "${BUILD_PATH}" "${JS_ASSET_PATH}"
+
+echo "==> Building site..."
+
+npm run build
+
+echo "==> Checking the HTML"
+
+bundle exec htmlproofer ${BUILD_PATH} \
+    --ignore-status-codes "$IGNORE_HTTP_STATUS" \
+    --ignore-urls "$IGNORE_HREFS" \
+    "$@"

--- a/src/contributing/managing-the-playbook.md
+++ b/src/contributing/managing-the-playbook.md
@@ -90,7 +90,7 @@ The owners of each section are:
   [The work we do > Supporting services](/work-we-do/supporting-services/)
 * Wendy Coello -
   [The work we do > Sharing our expertise](/work-we-do/sharing-expertise/)
-* Poss Apostolou - [Working here](/working-here/)
+* Poss Apostolou - [Staff handbook](/staff-handbook/)
 * Coca Rivas - Our professions
 
 ### Workflow

--- a/src/staff-handbook/dxw-time.md
+++ b/src/staff-handbook/dxw-time.md
@@ -41,4 +41,4 @@ If you’re in one of our billable teams, please talk to your line manager and a
 
 ## Non-billable staff
 
-Of course, people in our non-billable teams also get involved in company-wide work and [personal learning and development activity](staff-handbook/learning-and-development/) outside of their day jobs. This should be agreed with their line manager as part of their objectives in a similar way.
+Of course, people in our non-billable teams also get involved in company-wide work and [personal learning and development activity](/staff-handbook/learning-and-development/) outside of their day jobs. This should be agreed with their line manager as part of their objectives in a similar way.

--- a/src/staff-handbook/pay-pension-and-benefits/benefits.md
+++ b/src/staff-handbook/pay-pension-and-benefits/benefits.md
@@ -12,9 +12,9 @@ Benefits for permanent employees include:
 
 * [Electric vehicle scheme](https://www.electriccarscheme.com)
 
-* up to 18 weeks of paid [parental leave](/staff-handbook/policies/parental-leave-policy/) depending on your situation
+* up to 18 weeks of paid [parental leave](/staff-handbook/policies-and-procedures/parental-leave-policy/) depending on your situation
 
-* 25 days [holiday plus bank holidays](/staff-handbook/leave/#holiday)
+* 25 days [holiday plus bank holidays](/staff-handbook/leave/holiday/)
 
 * [pension](/staff-handbook/pay-pension-and-benefits/pension/) with up to 5% matching contribution from dxw
 

--- a/src/staff-handbook/policies-and-procedures/inclusion-diversity-equality.md
+++ b/src/staff-handbook/policies-and-procedures/inclusion-diversity-equality.md
@@ -105,7 +105,7 @@ If you need further support, in addition to any support we are able to provide y
 
 ## Recruitment and selection
 
-[Recruitment](/working-here/hiring-new-people/), promotion, and other selection exercises will be carried out on the basis of merit and against objective criteria
+[Recruitment](/staff-handbook/recruitment-process/), promotion, and other selection exercises will be carried out on the basis of merit and against objective criteria
 that aim to avoid discrimination. Shortlisting should be done by more than one
 person and with the involvement of the commercial operations team. Our
 recruitment procedures must be reviewed at least annually including the
@@ -164,7 +164,7 @@ avoid discrimination and improve equality and diversity.
 
 Training needs will be identified through regular conversations between line
 managers and their reports. All employees will be given appropriate
-[access to training](/learning-and-development/) to enable them to progress
+[access to training](/staff-handbook/learning-and-development/) to enable them to progress
 within the organisation. If training needs are identified then your Line Manager
 will work out the best to pay for this. This may be part of your Learning and
 Development, or something you, dxw or a third party pay for.
@@ -180,7 +180,7 @@ obstacles to accessing them.
 
 ## Termination of employment
 
-We will ensure that [redundancy criteria and procedures](/working-here/redundancy-policy/) are fair and objective
+We will ensure that [redundancy criteria and procedures](/staff-handbook/policies-and-procedures/redundancy-policy/) are fair and objective
 and are not directly or indirectly discriminatory. Demonstrated through
 independent consultation, sharing criteria openly and demonstrating our
 workings.

--- a/src/staff-handbook/policies-and-procedures/sickness-policy.md
+++ b/src/staff-handbook/policies-and-procedures/sickness-policy.md
@@ -38,7 +38,7 @@ support you to need fewer absences. We might also agree an action plan and / or
 a review period. Where we think it would be helpful, we'll seek advice via an
 Occupational Health advisor.
 
-If you have a long term health condition and would like to discuss [reasonable adjustments](staff-handbook/policies-and-procedures/inclusion-diversity-equality/#reasonable-adjustments) and ways of working that will help, we welcome a conversation at any
+If you have a long term health condition and would like to discuss [reasonable adjustments](/staff-handbook/policies-and-procedures/inclusion-diversity-equality/#reasonable-adjustments) and ways of working that will help, we welcome a conversation at any
 point. The sooner we know, the sooner we can support you.
 
 ## Sick pay

--- a/src/staff-handbook/supporting-wellbeing/getting-support-internally.md
+++ b/src/staff-handbook/supporting-wellbeing/getting-support-internally.md
@@ -6,15 +6,15 @@ last_reviewed_at: ""
 
 The wellbeing of our teams is very important. So we offer the following to support your health and wellbeing:
 
-* Safe homeworking set-up: if you require any [ergonomic items](/working-here/getting-things-you-need/), additional travel support or an assessment of your home or office working set up ([DSE](https://www.hse.gov.uk/msd/dse/)), you can find support through your line manager and the People team to arrange this.
+* Safe homeworking set-up: if you require any [ergonomic items](/staff-handbook/pay-pension-and-benefits/benefits/#home-office-equipment), additional travel support or an assessment of your home or office working set up ([DSE](https://www.hse.gov.uk/msd/dse/)), you can find support through your line manager and the People team to arrange this.
 * Accessibility information for our shared office spaces can be found [here](/guides/office-accessibility) and please speak to the People team if you’re interested in support with digital accessibility.
-* Wellbeing based courses can be purchased through the [learning and development budget](/working-here/supporting-your-development-and-wellbeing/#learning-and-development), these are a taxable benefit.
-* Other benefits that address health: [Eyecare vouchers](/working-here/supporting-your-development-and-wellbeing/#eyecare-vouchers), Flu vaccine vouchers offered annually and [cycle to work scheme](/working-here/supporting-your-development-and-wellbeing/#cycle-to-work-scheme).
-* Bespoke dxw support paths to seek help and advice: [Slack groups](https://docs.google.com/document/d/1rIHYqFdEWSmjkUyScx-tIpoFrICO1hG7-SDnSLOR3JM/edit), [Buddy System, Helpers, Line Managers](/working-here/supporting-your-development-and-wellbeing/#other-support-paths) and [HR support](/working-here/supporting-your-development-and-wellbeing/#people-and-hr-team).
-* [Reasonable adjustments](/working-here/pay-pension-and-benefits/#sickness) to support a disability, long-term health conditions and times of change and challenge. (Some changes and challenges may be, pregnancy, caring responsibilities, menopause & hormone therapies, bereavement, mental and physical health diagnosis and ongoing long term conditions).
-* Taking the time you need ([compassionate, sick and annual leave](/working-here/pay-pension-and-benefits/)) - speak to your line manager for more details.
+* Wellbeing based courses can be purchased through the [learning and development budget](/staff-handbook/learning-and-development/how-to-use-your-learning-and-development-allowance/), these are a taxable benefit.
+* Other benefits that address health: [Eyecare vouchers](/staff-handbook/pay-pension-and-benefits/benefits/#eyecare-vouchers), Flu vaccine vouchers offered annually and [cycle to work scheme](/staff-handbook/pay-pension-and-benefits/benefits/#cycle-to-work-scheme).
+* Bespoke dxw support paths to seek help and advice: [Slack groups](https://docs.google.com/document/d/1rIHYqFdEWSmjkUyScx-tIpoFrICO1hG7-SDnSLOR3JM/edit), [buddies](#buddies), [helpers](#helpers), [line managers](#your-line-manager) and [People team support](#the-people-team).
+* [Reasonable adjustments](/staff-handbook/policies-and-procedures/inclusion-diversity-equality/#reasonable-adjustments) to support a disability, long-term health conditions and times of change and challenge. (Some changes and challenges may be, pregnancy, caring responsibilities, menopause & hormone therapies, bereavement, mental and physical health diagnosis and ongoing long term conditions).
+* Taking the time you need ([compassionate, sick and annual leave](/staff-handbook/leave/)) - speak to your line manager for more details.
 * Support through the [Access to Work](https://www.gov.uk/access-to-work) grant scheme for those with a disability or eligible health condition.
-* [Flexible working options](/working-here/pay-pension-and-benefits/#flexible-working) such as change of working pattern, hours or role/project, access to local hot desking and maintaining remote working, to support changing needs.
+* [Flexible working options](/staff-handbook/flexible-working/) such as change of working pattern, hours or role/project, access to local hot desking and maintaining remote working, to support changing needs.
 
 ## Mental and physical health support at a time of challenge or crisis
 
@@ -39,21 +39,21 @@ We also have a weekly Ask HR slot at 11am on Wednesdays, to provide a regular op
 The list is not exhaustive, but includes:
 
 * accessibility
-* [bereavement](/staff-handbook/leave/#compassionate-leave)
+* [bereavement](/staff-handbook/leave/compassionate-leave/)
 * contractual matters
-* [diversity and inclusion](/staff-handbook/policies/inclusion-diversity-equality/)
+* [diversity and inclusion](/staff-handbook/policies-and-procedures/inclusion-diversity-equality/)
 * [expenses](/staff-handbook/claiming-expenses/)
 * facilitation/scheduling of conversations with Directors/heads-of
-* [grievances](/staff-handbook/grievances/) and [disciplinary matters](/staff-handbook/disciplinary-procedure/)
-* [holiday](/staff-handbook/leave/#holiday)
+* [grievances](/staff-handbook/policies-and-procedures/grievances/) and [disciplinary matters](/staff-handbook/policies-and-procedures/disciplinary-procedure/)
+* [holiday](/staff-handbook/leave/holiday/)
 * interpersonal issues
-* [Mental health first aid](/wellbeing/where-to-get-support-internally/#mental-health-first-aiders)
+* [Mental health first aid](#mental-health-first-aiders)
 * occupational health issues
-* [pay](/pay-pension-and-benefits/pay/) (second line of support after line managers)
-* [parental leave](/staff-handbook/policies/parental-leave-policy/)
+* [pay](/staff-handbook/policies-and-procedures/pay-policy/) (second line of support after line managers)
+* [parental leave](/staff-handbook/policies-and-procedures/parental-leave-policy/)
 * probation
-* [pensions](/pay-pension-and-benefits/pension/)
-* [sickness](/staff-handbook/policies/sickness-policy/)
+* [pensions](/staff-handbook/pay-pension-and-benefits/pension/)
+* [sickness](/staff-handbook/policies-and-procedures/sickness-policy/)
 * stress management
 * training and career progression
 * [working patterns](/staff-handbook/flexible-working/) and [locations](/staff-handbook/when-and-where-you-work/)
@@ -64,13 +64,13 @@ Line managers are your first point of contact for any issues you may be having a
 
 They can listen, support and offer reasonable adjustments as detailed above. They can help review workloads, working patterns, projects, roles and responsibilities and help with resolving anything within the workplace that might be causing concern. They can liaise with delivery leads, heads of and directors where necessary, and take some of the burden from you.
 
-### Mental Health First Aiders
+### Mental health first aiders
 
-If you are experiencing a mental health crisis or think that someone else is, we have a team of trained mental health first aiders who are able to provide initial support. A Mental Health First Aider is able to listen and communicate non-judgementally, give initial support and then signpost information or appropriate professional help.
+If you are experiencing a mental health crisis or think that someone else is, we have a team of trained Mental health first aiders who are able to provide initial support. A Mental Health First Aider is able to listen and communicate non-judgementally, give initial support and then signpost information or appropriate professional help.
 
 First aiders are a safe place to turn to if you are experiencing an issue with your mental health, and need to talk to someone. Conversations will be kept in strictest confidence, provided that you are not at serious risk of harm.
 
-Mental Health First Aiders are identified in the [company directory in Breathe](https://hr.breathehr.com/employees/directory?name=&company_department_id=&company_division_id=&mh=true), and you can reach out to them via Slack or email.
+Mental health first aiders are identified in the [company directory in Breathe](https://hr.breathehr.com/employees/directory?name=&company_department_id=&company_division_id=&mh=true), and you can reach out to them via Slack or email.
 
 If your chosen MHFA is unable to take a call, they will offer to refer you to another first aider or a member of the People team.
 

--- a/src/user-research/choosing-and-using-analysis-and-synthesis-methods.md
+++ b/src/user-research/choosing-and-using-analysis-and-synthesis-methods.md
@@ -156,6 +156,6 @@ There are a number of ways we can create the codes. We can start with a set of p
 * [How to Analyze Qualitative Data from UX Research: Thematic Analysis](https://www.nngroup.com/articles/thematic-analysis/)
 * [Qualitative data coding 101 at Grad Coach](https://gradcoach.com/qualitative-data-coding-101/)
 * [An Introduction to Codes and Coding by Saldana (book chapter)](https://www.sagepub.com/sites/default/files/upm-binaries/24614_01_Saldana_Ch_01.pdf)
-* [Ground Theory: A practical guide by Birks and Mills](https://us.sagepub.com/en-us/nam/grounded-theory/book2431770)
+* [Grounded Theory: A Practical Guide by Birks and Mills](https://uk.sagepub.com/en-gb/eur/grounded-theory/book243177)
 * [Qualitative Data Analysis: A Methods Sourcebook by Miles, Huberman and Saldana](https://us.sagepub.com/en-us/nam/qualitative-data-analysis/book246128)
 (quite expensive new, but can often get cheaper second hand copies)

--- a/src/user-research/doing-research-safely.md
+++ b/src/user-research/doing-research-safely.md
@@ -19,7 +19,7 @@ research.
 For now, you will need the approval of a Director, Head or Principal Researcher
 to do face to face research. And you must document your decision and your
 assessment of the risks in your
-[research plan](#how-we-create-and-use-research-plans).
+[research plan](/user-research/creating-and-using-research-plans/).
 
 The Service Manual has a guide to
 [choosing face to face or remote research](https://www.gov.uk/service-manual/user-research/doing-user-research-during-coronavirus-covid-19-choosing-face-to-face-or-remote-research),

--- a/src/who-we-are/index.md
+++ b/src/who-we-are/index.md
@@ -142,9 +142,9 @@ However, there are some things that we must keep private.
   confidential.
 * We also hold some personal data about and/or on behalf of our clients. We
   never share any of this data, including contact details. See also:
-  [data protection](/working-here/data-protection-and-confidentiality/).
+  [data protection](/staff-handbook/data-protection-and-confidentiality/).
 * We are sometimes sent documents that are
-  [protectively marked](/working-here/data-protection-and-confidentiality/#protective-marking-scheme),
+  [protectively marked](/staff-handbook/data-protection-and-confidentiality/#protective-marking-scheme),
   and we have a scheme of our own. Information in these documents is
   confidential.
 * Information about work that is currently being procured (whether we are
@@ -199,7 +199,7 @@ We’re committed to being transparent with our diversity information and
 regularly assessing the impact of all our policies and practices.
 
 Our approach is set out in our
-[Inclusion, diversity and equal opportunities policy](/working-here/inclusion-diversity-equality/).
+[Inclusion, diversity and equal opportunities policy](/staff-handbook/policies-and-procedures/inclusion-diversity-equality/).
 
 Thank you for being you - it makes us better.
 

--- a/src/work-we-do/building-services/running-a-discovery-kick-off-workshop.md
+++ b/src/work-we-do/building-services/running-a-discovery-kick-off-workshop.md
@@ -15,7 +15,7 @@ be, and whether we’re looking at a single service or cutting across several. S
 we use a broader set of questions.
 
 These are based on the
-[questions to frame a problem](https://www.hollidazed.co.uk/2015/07/28/frame-the-problem)
+[questions to frame a problem](https://benholliday.com/2015/07/28/frame-the-problem)
 that [Ben Holiday](https://twitter.com/BenHolliday) wrote about, the
 [discovery inception categories](https://www.myddelton.co.uk/blog/setting-up-a-discovery)
 that [Will Myddelton](https://twitter.com/myddelton) described, along with some


### PR DESCRIPTION
This fixes a bunch of internal 404s, mostly from the working here -> staff handbook restructure. It also updates some `/working-here` links that weren't 404s thanks to redirects being set up. There's also one casing change for consistency, where this section (mental health first aiders) was being linked to

Also fixed are two external 404s - the rest were false positives

Lastly, a script is added (mostly taken from #977) to run the HTML checker, ignoring known false positives. This is not yet integrated into the CI - doing so may create extra overhead if non-technical staff make edits that introduce false positives (see discussion below, in #977 and the Slack conversation linked therein)

Closes #977