### PR TITLE
Adding additional Landmark spaces to Our offices page

### DIFF
--- a/src/staff-handbook/our-offices.md
+++ b/src/staff-handbook/our-offices.md
@@ -15,7 +15,7 @@ Calls Landing <br>36-38 The Calls <br>Leeds<br>LS2 7EW <br>0113 212 0687
 
 There's a [Leeds Office Guide](https://docs.google.com/document/d/1jHsQJH__2sZssJYZiLqLPyDjZWl5Ixhscx4R-0hMDXs/edit) available if you would like to work from this space.
 
-If you need any support with using this space, post your question in the #leeds-office channel and a member of the team will be able to help.
+If you need any support with using this space, post your question in the #dxw-leeds-office channel and a member of the team will be able to help.
 
 If you need any further information about any features of the office that could impact your access, please email us at [contact@dxw.com](mailto:contact@dxw.com) or call 0113 212 0687.
 

--- a/src/staff-handbook/our-offices.md
+++ b/src/staff-handbook/our-offices.md
@@ -26,3 +26,21 @@ dxw has access to [The Lighthouse](https://www.landmarkspace.co.uk/locations/lon
 1 The Lighthouse Building <br>370 Grays Inn Road <br>London <br>WC1X 8BB
 
 If you need any support with using this space, post your question in the #dxw-london-office channel or email [KingsCross@landmarkspace.co.uk](mailto:KingsCross@landmarkspace.co.uk) for support.
+
+## Other coworking spaces in the UK
+
+dxw staff can use any of [Landmark's coworking spaces](https://www.landmarkspace.co.uk/search-results/?value=united+kingdom) in:
+
+* London 
+
+* Manchester 
+
+* Birmingham 
+
+* Bristol 
+
+* Milton Keynes 
+
+* Reading
+
+If you want to use a Landmark coworking space, email [KingsCross@landmarkspace.co.uk](mailto:KingsCross@landmarkspace.co.uk) and let them know you're from dxw, and about any guests you want to bring.


### PR DESCRIPTION
Updating the office page to include other Landmark offices we can use. 

Also to add missing 'dxw-' to Slack channel name for Leeds office.