### PR TITLE
Capture search terms in playbook analytics

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -23,31 +23,6 @@
 
     <link rel="stylesheet" href="/assets/main.css"/>
     <script defer data-domain="playbook.dxw.com" src="https://plausible.io/js/script.manual.js"></script>
-    <!-- define the `plausible` function to manually trigger events - as the pageview event is not being sent automatically with 'script.manual.js' -->
-    <script>
-      window.plausible = window.plausible || function () {
-        (window.plausible.q = window.plausible.q || []).push(arguments)
-      }
-    </script>
-
-    <!-- trigger pageview -->
-    <script>
-      function prepareUrl(params) {
-        const url = new URL(location.href)
-        const queryParams = new URLSearchParams(location.search)
-        let customUrl = url.protocol + "//" + url.hostname + url
-          .pathname
-          .replace(/\/$/, '')
-        for (const paramName of params) {
-          const paramValue = queryParams.get(paramName)
-          if (paramValue) {
-            customUrl = customUrl + '/' + paramValue
-          }
-        }
-        return customUrl
-      }
-      plausible('pageview', {u: prepareUrl([])})
-    </script>
   </head>
   <body>
     {% include navbar.html %}
@@ -56,5 +31,6 @@
       {% include page-content.html %}
     </main>
     {% include contribute.html %}
+    <script src="/assets/js/plausible.js"></script>
   </body>
 </html>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en-GB">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8"/>
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
+/>
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon/favicon-16x16.png">
@@ -21,8 +21,33 @@
       <script src="/assets/js/redirect.js"></script>
     {% endif %}
 
-    <link rel="stylesheet" href="/assets/main.css" />
-    <script defer data-domain="playbook.dxw.com" src="https://plausible.io/js/plausible.js"></script>
+    <link rel="stylesheet" href="/assets/main.css"/>
+    <script defer data-domain="playbook.dxw.com" src="https://plausible.io/js/script.manual.js"></script>
+    <!-- define the `plausible` function to manually trigger events - as the pageview event is not being sent automatically with 'script.manual.js' -->
+    <script>
+      window.plausible = window.plausible || function () {
+        (window.plausible.q = window.plausible.q || []).push(arguments)
+      }
+    </script>
+
+    <!-- trigger pageview -->
+    <script>
+      function prepareUrl(params) {
+        const url = new URL(location.href)
+        const queryParams = new URLSearchParams(location.search)
+        let customUrl = url.protocol + "//" + url.hostname + url
+          .pathname
+          .replace(/\/$/, '')
+        for (const paramName of params) {
+          const paramValue = queryParams.get(paramName)
+          if (paramValue) {
+            customUrl = customUrl + '/' + paramValue
+          }
+        }
+        return customUrl
+      }
+      plausible('pageview', {u: prepareUrl([])})
+    </script>
   </head>
   <body>
     {% include navbar.html %}

--- a/src/_webpack/plausible.js
+++ b/src/_webpack/plausible.js
@@ -1,0 +1,21 @@
+// define the `plausible` function to manually trigger events
+window.plausible = window.plausible || function () {
+  (window.plausible.q = window.plausible.q || []).push(arguments)
+}
+
+function prepareUrl (params) {
+  const url = new URL(window.location.href)
+  const queryParams = new URLSearchParams(window.location.search)
+  let customUrl = url.protocol + '//' + url.hostname + url
+    .pathname
+    .replace(/\/$/, '')
+  for (const paramName of params) {
+    const paramValue = queryParams.get(paramName)
+    if (paramValue) {
+      customUrl = customUrl + '/' + paramValue
+    }
+  }
+  return customUrl
+}
+
+window.plausible('pageview', { u: prepareUrl([]) })

--- a/src/_webpack/plausible.js
+++ b/src/_webpack/plausible.js
@@ -1,15 +1,21 @@
-// define the `plausible` function to manually trigger events
-window.plausible = window.plausible || function () {
-  (window.plausible.q = window.plausible.q || []).push(arguments)
+const captureAllPageViews = (paramsToRegister) => {
+  definePlausibleFunction()
+  window.plausible('pageview', { u: prepareUrl(paramsToRegister) })
 }
 
-function prepareUrl (params) {
+const definePlausibleFunction = () => {
+  window.plausible = window.plausible || function () {
+    (window.plausible.q = window.plausible.q || []).push(arguments)
+  }
+}
+
+const prepareUrl = (paramsToRegister) => {
   const url = new URL(window.location.href)
   const queryParams = new URLSearchParams(window.location.search)
   let customUrl = url.protocol + '//' + url.hostname + url
     .pathname
     .replace(/\/$/, '')
-  for (const paramName of params) {
+  for (const paramName of paramsToRegister) {
     const paramValue = queryParams.get(paramName)
     if (paramValue) {
       customUrl = customUrl + '/' + paramValue
@@ -18,4 +24,4 @@ function prepareUrl (params) {
   return customUrl
 }
 
-window.plausible('pageview', { u: prepareUrl([]) })
+captureAllPageViews(['query'])

--- a/src/_webpack/plausible.js
+++ b/src/_webpack/plausible.js
@@ -16,7 +16,8 @@ const prepareUrl = (paramsToRegister) => {
     .pathname
     .replace(/\/$/, '')
   for (const paramName of paramsToRegister) {
-    const paramValue = queryParams.get(paramName)
+    const paramValue = queryParams.get(paramName)?.split(' ').join('+')
+
     if (paramValue) {
       customUrl = customUrl + '/' + paramValue
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,8 @@ const path = require('path')
 module.exports = {
   entry: {
     search: path.join(__dirname, 'src/_webpack/search'),
-    redirect: path.join(__dirname, 'src/_webpack/redirect')
+    redirect: path.join(__dirname, 'src/_webpack/redirect'),
+    plausible: path.join(__dirname, 'src/_webpack/plausible')
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
This adds the ability to track common search terms on the playbook using our analytics tool [Plausible](https://plausible.io/docs).  

This is related to issue #1024 and was a suggestion from the content team. In order to inform future content changes (e.g. restructures), it might be useful to have some kind of analytics to track common search terms. This has two benefits:
- understanding what might be difficult to find by standard navigation
- highlighting potential content gaps in the playbook

By default Plausible strips query params from urls to count page views. We can however, use a custom script to [capture query parameters](https://plausible.io/docs/custom-query-params), and track them as page views in Plausible. 

## How it works
By creating a 'Goal' for the `/search*` url in the Plausible dashboard, we can still view the total number of visitors to the search page. When clicking on the goal, common terms are listed as pages under the 'Top pages' section. Common search terms will also be listed under general page views, but this is an easy way to view them together. 

![Goals shown on the Plausible Dashboard showing 'Search' goal](https://github.com/dxw/playbook/assets/50752284/8000faf1-b959-45ce-8c4b-7f2a46824936 "Plausible goals - search")
![Top search terms shown as page views](https://github.com/dxw/playbook/assets/50752284/d0f83a49-c929-45c4-8bef-ea4f09524767 "Plausible top search terms")

## Things to note

### Special characters
This solution currently only handles spaces in search terms, and joins them together using a '-'. It does not remove other special characters. However, special characters are shown on the plausible dashboard (see example below). It is also worth noting that search itself does not currently handle special characters. This does mean that there may be more variations of the same or similar terms though - which might create additional work when analysing the top terms.
![Special characters are shown in the plausible dashboard](https://github.com/dxw/playbook/assets/50752284/9a852b4c-134d-4599-95b0-b2ced7e21171 "Plausible search terms - special characters")

## What's next
We are also looking ways to understand if people are finding what they're looking for on the playbook. One suggestion is to add a button on the search page to let users let us know themselves (linked to a simple form).