### PR TITLE
New layout

### DIFF
--- a/src/_includes/contribute.html
+++ b/src/_includes/contribute.html
@@ -13,9 +13,9 @@
   {% endif %}
 {% endif %}
 
-<footer class="contribute" data-proofer-ignore>
-  <a href="/admin/#/collections/{{ collection_name }}/entries/{{ entry_name }}">Edit this page</a>
+<div class="contribute" data-proofer-ignore>
+  <a href="/admin/#/collections/{{ collection_name }}/entries/{{ entry_name }}">Edit page</a>
   {% unless page.url == "/" %}
-    <a href="/admin/#/collections/{{ collection_name }}/new">Add a new page here</a>
+    <a href="/admin/#/collections/{{ collection_name }}/new">Add new page</a>
   {% endunless %}
-</footer>
+</div>

--- a/src/_includes/navbar.html
+++ b/src/_includes/navbar.html
@@ -1,14 +1,12 @@
-<header>
-  <nav aria-label="Main" class="navbar">
-    <ul>
-      <li>
-        <a href="/" aria-label="Homepage">
-            <img src="/assets/images/dxw-logo.png" alt="" />
-        </a>
-      </li>
-      <li class="navbar__search">
-        {% include search_form.html %}
-      </li>
-    </ul>
-  </nav>
-</header>
+<nav aria-label="Main" class="navbar">
+  <ul>
+    <li>
+      <a href="/" aria-label="Homepage">
+          <img src="/assets/images/dxw-logo.png" alt="" />
+      </a>
+    </li>
+    <li class="navbar__search">
+      {% include search_form.html %}
+    </li>
+  </ul>
+</nav>

--- a/src/_includes/page-content.html
+++ b/src/_includes/page-content.html
@@ -8,7 +8,7 @@
   {% assign stripped_content = content | strip %}
   {% if stripped_content == "" %}
     <ul>
-      {% include related_pages.html %}
+      {% include related_pages.html in-nav=false %}
     </ul>
   {% else %}
     {% include anchor_headings.html html=content anchorBody="#" anchorAttrs='aria-label="Permalink to %heading%"' %}

--- a/src/_includes/page-content.html
+++ b/src/_includes/page-content.html
@@ -3,28 +3,26 @@
 {% capture commit_history_url %}https://github.com/dxw/playbook/commits/main/src/{{ page.path }}{% endcapture %}
 
 <article class="page-content">
-  <div>
-    <h1>{{ page.title }}</h1>
+  <h1>{{ page.title }}</h1>
 
-    {% assign stripped_content = content | strip %}
-    {% if stripped_content == "" %}
-      <ul>
-        {% include related_pages.html %}
-      </ul>
-    {% else %}
-      {% include anchor_headings.html html=content anchorBody="#" anchorAttrs='aria-label="Permalink to %heading%"' %}
+  {% assign stripped_content = content | strip %}
+  {% if stripped_content == "" %}
+    <ul>
+      {% include related_pages.html %}
+    </ul>
+  {% else %}
+    {% include anchor_headings.html html=content anchorBody="#" anchorAttrs='aria-label="Permalink to %heading%"' %}
 
-      <hr>
-  
-      <p>
-        <i>
-          {% if last_reviewed_at > last_modified_at %}
-            Last reviewed: {{ page.last_reviewed_at | date: "%-d %B %Y" }}
-            <br>
-          {% endif %}
-          Last updated: {{ page.last_modified_at | date: "%-d %B %Y" }} (<a href="{{ commit_history_url }}">history</a>)
-        </i>
-      </p>    
-    {% endif %}
-  </div>
+    <hr>
+
+    <p id="last-review-and-updated">
+      <i>
+        {% if last_reviewed_at > last_modified_at %}
+          Last reviewed: {{ page.last_reviewed_at | date: "%-d %B %Y" }}
+          <br>
+        {% endif %}
+        Last updated: {{ page.last_modified_at | date: "%-d %B %Y" }} (<a href="{{ commit_history_url }}">history</a>)
+      </i>
+    </p>    
+  {% endif %}
 </article>

--- a/src/_includes/related.html
+++ b/src/_includes/related.html
@@ -6,7 +6,7 @@
       {% if parent_page %}
         {% unless parent_page.unrelatable %}
           <li class="related__back-link">
-            <a href="{{ parent_page.url }}">ᐊ {{ parent_page.title }}</a>
+            <a href="{{ parent_page.url }}">{{ parent_page.title }}</a>
           </li>
         {% endunless %}
       {% endif %}

--- a/src/_includes/related.html
+++ b/src/_includes/related.html
@@ -11,7 +11,7 @@
         {% endunless %}
       {% endif %}
 
-      {% include related_pages.html %}
+      {% include related_pages.html in-nav=true %}
     </ul>
   </nav>
 </aside>

--- a/src/_includes/related_pages.html
+++ b/src/_includes/related_pages.html
@@ -12,6 +12,9 @@
     {% endunless %}
   {% endfor %}
 {% endfor %}
+
+{% if include.in-nav %}
   <li>
     <a href="https://www.dxw.com/contact/">Contact dxw</a>
   </li>
+{% endif %}

--- a/src/_includes/related_pages.html
+++ b/src/_includes/related_pages.html
@@ -3,7 +3,7 @@
   {% assign related_pages = related_page_group.items | sort_natural: "title" %}
 
   {% for related_page in related_pages %}
-    {% unless related_page.unrelatable %}
+    {% unless related_page.unrelatable or (related_page.title.size == 0) %}
       <li>
         <a href="{{ related_page.url }}">
           {{ related_page.title }}

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -25,12 +25,14 @@
     <script defer data-domain="playbook.dxw.com" src="https://plausible.io/js/script.manual.js"></script>
   </head>
   <body>
-    {% include navbar.html %}
-    <main>
+    <header>
+      {% include navbar.html %}
       {% include related.html %}
+      {% include contribute.html %}
+    </header>
+    <main>
       {% include page-content.html %}
     </main>
-    {% include contribute.html %}
     <script src="/assets/js/plausible.js"></script>
   </body>
 </html>

--- a/src/_sass/_contribute.scss
+++ b/src/_sass/_contribute.scss
@@ -3,25 +3,27 @@
 @use "./typography";
 
 .contribute {
-  display: none;
-}
+  @include breakpoints.on-large-screens {
+    position: fixed;
+    bottom: 0;
+    left: 0;
 
-@include breakpoints.on-large-screens {
-  .contribute {
     display: flex;
-    justify-content: space-evenly;
+    justify-content: space-between;
 
-    padding: 0.5em;
+    width: 330px;
+    padding: 1em;
 
     font-family: typography.$heading-font-family;
-    font-size: 1.2em;
+    font-size: 0.9em;
     font-weight: typography.$heading-font-weight;
-    text-align: center;
 
     background-color: colours.$accent-a;
-
+  
     a {
       margin: 0;
     }
   }
+
+  display: none;
 }

--- a/src/_sass/_layout.scss
+++ b/src/_sass/_layout.scss
@@ -1,19 +1,43 @@
 @use "./breakpoints";
 @use "./navbar";
 
+$large-screen-header-width: 330px;
+
 * {
   box-sizing: border-box;
 }
 
-main {
-  @include breakpoints.on-large-screens {
-    flex-direction: row;
-    height: calc(100vh - navbar.$height-large - 3em);
-    margin-top: navbar.$height-large;
-  }
+header {
+  width: 100%;
+}
 
+body {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - navbar.$height);
-  margin-top: navbar.$height;
+  min-height: 100vh;
+}
+
+main {
+  flex: 1;
+}
+
+@include breakpoints.on-large-screens {
+  body {
+    flex-direction: row;
+  }
+
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+
+    width: $large-screen-header-width;
+    height: 100vh;
+  }
+
+  main {
+    height: 100%;
+    min-height: 100vh;  
+    margin-left: $large-screen-header-width;
+  }
 }

--- a/src/_sass/_navbar.scss
+++ b/src/_sass/_navbar.scss
@@ -6,12 +6,9 @@ $height: 135.008px; // Manually measured after layout.
 $height-large: 85.016px; // Manually measured after layout.
 
 .navbar {
-  position: fixed;
-  z-index: 1;
-  top: 0;
-  right: 0;
-  left: 0;
-
+  display: flex;
+  flex-direction: column;
+  padding: 1em;
   background-color: colours.$navy;
 
   a {
@@ -33,31 +30,17 @@ $height-large: 85.016px; // Manually measured after layout.
   }
 
   > ul {
-    @include breakpoints.on-large-screens {
-      display: flex;
-      align-items: center;
-      justify-content: flex-end;  
-    }
-
-    margin: 1em;
+    margin: 0;
     padding: 0;
     list-style: none;
 
     > li {
-      margin-bottom: 0;
+      margin: 0;
 
       &:first-child {
-        margin-right: auto;
+        margin-bottom: 1em;
       }
     }
-  }
-
-  &__search {
-    @include breakpoints.on-large-screens {
-      margin-top: 0;
-    }
-
-    margin-top: 1em;
   }
 }
 

--- a/src/_sass/_page-content.scss
+++ b/src/_sass/_page-content.scss
@@ -2,60 +2,62 @@
 
 @use "./colours";
 
-$font-size: 1em;
-
 .page-content {
   will-change: scroll-position;
   scroll-behavior: smooth;
 
   overflow-y: auto;
-  flex: 1;
 
-  padding: 0.5em 2em 5em;
+  max-width: 40em;
+  margin: 0 auto;
+  padding: 2em;
 
-  font-size: $font-size;
+  font-size: 1em;
 
-  > div {
-    max-width: 40em;
-    margin: 0 auto;
+  > h1 {
+    margin-top: 0;
+  }
 
-    > h1,
-    > h2,
-    > h3,
-    > h4,
-    > h5,
-    > h6 {
-      margin-right: -0.5em;
-      margin-left: -0.5em;
-      padding-right: 0.5em;
-      padding-left: 0.5em;
+  > h1,
+  > h2,
+  > h3,
+  > h4,
+  > h5,
+  > h6 {
+    margin-right: -0.5em;
+    margin-left: -0.5em;
+    padding-right: 0.5em;
+    padding-left: 0.5em;
 
-      a {
-        font-size: 0.7em;
-        color: colours.$accent-b;
-        text-decoration: none;
-        vertical-align: middle;
+    a {
+      font-size: 0.7em;
+      color: colours.$accent-b;
+      text-decoration: none;
+      vertical-align: middle;
 
-        transition: color 0.2s;
+      transition: color 0.2s;
 
-        &:hover,
-        &:focus,
-        &:active {
-          color: colours.$navy;
-        }
-      }
-
-      &:target a {
-        display: none;
+      &:hover,
+      &:focus,
+      &:active {
+        color: colours.$navy;
       }
     }
 
-    :target {
-      background: colours.$yellow-light;
+    &:target a {
+      display: none;
     }
+  }
+
+  :target {
+    background: colours.$yellow-light;
   }
 
   img {
     max-width: 100%;
   }
+}
+
+#last-review-and-updated {
+  margin-bottom: 0;
 }

--- a/src/_sass/_related.scss
+++ b/src/_sass/_related.scss
@@ -2,6 +2,10 @@
 @use "./colours";
 @use "./typography";
 
+$large-screen-nav-height: 134.992px;
+$large-screen-contribute-height: 63px;
+$list-d-size: 11px;
+
 .related {
   overflow-y: auto;
 
@@ -46,31 +50,44 @@
 
 @include breakpoints.on-large-screens {
   .related {
-    width: 21em;
-    max-width: 30vw;
-    height: 100%;
+    height: calc(100vh - $large-screen-nav-height - $large-screen-contribute-height);
     padding: 1.5em 1em;
-
     background-color: colours.$cream;
-
-    a {
-      margin-bottom: 0.5em;
-      padding-left: 2em;
-      text-indent: -2em;
-
-      &:hover,
-      &:focus,
-      &:active {
-        text-decoration-color: colours.$accent-a;
-      }
-    }
-
+    
     ul li {
       padding-right: 0;
       white-space: unset;
 
+      a {
+        &:hover,
+        &:focus,
+        &:active {
+          text-decoration-color: colours.$accent-a;
+        }
+      }
+      
       &.related__back-link {
         margin-bottom: 1.5em;
+        padding-left: 0;
+      }
+
+      &:not(:is(:last-child, .related__back-link)) {
+        margin-bottom: 0.5em;
+      }
+  
+      &:not(.related__back-link)::before {
+        content: "";
+  
+        position: absolute;
+        top: 8px;
+        left: 0;
+  
+        width: $list-d-size;
+        height: $list-d-size;
+  
+        background: url("/assets/images/d-symbol-blue.svg");
+        background-repeat: no-repeat;
+        background-size: contain;
       }
     }
 

--- a/src/_sass/_related.scss
+++ b/src/_sass/_related.scss
@@ -14,7 +14,6 @@ $list-d-size: 11px;
 
   font-family: typography.$heading-font-family;
   font-size: 0.9em;
-  font-weight: typography.$heading-font-weight;
 
   background-color: colours.$accent-a;
 
@@ -55,7 +54,9 @@ $list-d-size: 11px;
     background-color: colours.$cream;
     
     ul li {
+      position: relative;
       padding-right: 0;
+      padding-left: calc($list-d-size + 10px);
       white-space: unset;
 
       a {
@@ -68,7 +69,13 @@ $list-d-size: 11px;
       
       &.related__back-link {
         margin-bottom: 1.5em;
-        padding-left: 0;
+
+        &::before {
+          content: "ᐊ";
+          position: absolute;
+          top: 0;
+          left: 0;
+        }
       }
 
       &:not(:is(:last-child, .related__back-link)) {

--- a/src/_sass/_typography.scss
+++ b/src/_sass/_typography.scss
@@ -6,7 +6,7 @@ $body-font-weight-bold: 700;
 $heading-font-family: poppins, sans-serif;
 $heading-font-weight: 600;
 
-@import "https://fonts.googleapis.com/css?family=Poppins:600&display=swap";
+@import "https://fonts.googleapis.com/css?family=Poppins:400,600&display=swap";
 @import "https://fonts.googleapis.com/css?family=Cardo:400,700&display=swap";
 
 body {

--- a/src/assets/images/d-symbol-blue.svg
+++ b/src/assets/images/d-symbol-blue.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="154" viewBox="0 0 128 154" fill="none"><style xmlns="http://www.w3.org/1999/xhtml">.background{fill:#f3f1e9;}.bt-all{fill:#009abf;}.bt-editable-text{display: none}.bt-textarea{display: none}</style>
+<path d="M51.4286 0.428574H0.571411V153.286H51.4286C93.4677 153.286 127.714 119.18 127.714 76.8571C127.714 34.5338 93.4677 0.428574 51.4286 0.428574Z" class="marque bt-all"/>
+</svg>


### PR DESCRIPTION
Closes #1199
Closes #1142

See those issues for more context

## Summary of changes

On large screens:
- the top menu and contribution footer are now constrained width, in line with the main navigation menu
- the main content of the page is now full height, giving it more space
- the main navigation menu is restyled to make it easier to scan: reduced font weight (also on small screens); list item indicator (a style taken from our main site's [impact report](https://www.dxw.com/dxw-impact)); no second line indent

On all screen sizes:
- index pages no longer include the 'Contact dxw' link, but this still appears in the main navigation menu

## Previews

### Interactive

Available at https://deploy-preview-1204--laughing-payne-b9fbd2.netlify.app

### Video

https://github.com/dxw/playbook/assets/40244233/4ec39e1e-41e6-4767-9663-830aa5636704