### PR TITLE
Simplify principle description

### DIFF
--- a/src/user-research/index.md
+++ b/src/user-research/index.md
@@ -17,7 +17,7 @@ Our principles are not rules. They guide our work, keep us improving as a team, 
 
 1. **Help teams understand and value people**
 
-   Researchers at dxw help our teams to build a deep understanding of the people who use our services, and to value and act on that understanding. That’s how we contribute to good decisions and public services that work well for the people who need them.
+   Researchers at dxw help our teams to build a deep understanding of the people who use our services, and to value and act on that understanding. So our teams can make good decisions and create public services that work well for the people who need them.
 
    We are facilitators, not gatekeepers. We actively involve our colleagues and clients in research. And openly share what we do, how we do it and why it’s important.
 

--- a/src/user-research/index.md
+++ b/src/user-research/index.md
@@ -17,7 +17,7 @@ Our principles are not rules. They guide our work, keep us improving as a team, 
 
 1. **Help teams understand and value people**
 
-   Researchers at dxw help our teams to build a deep understanding of the people who use our services, and to value and act on that understanding. So our teams can make good decisions and create public services that work well for the people who need them.
+   Researchers at dxw help our teams to build a deep understanding of the people who use our services, and to value and act on that understanding. We know that’s the best way we can help teams make good decisions and create public services that work well for the people who need them.
 
    We are facilitators, not gatekeepers. We actively involve our colleagues and clients in research. And openly share what we do, how we do it and why it’s important.
 


### PR DESCRIPTION
One final tweak, hopefully, to simplify the descriptions of the principles we've been working on.

Note that the proposal to improve these two principles came from a recent user researcher away day.