### PR TITLE
Add page on GovPress ways of working

### DIFF
--- a/src/govpress-unit/ways-of-working.md
+++ b/src/govpress-unit/ways-of-working.md
@@ -1,0 +1,78 @@
+---
+title: Ways of working
+last_reviewed_at: ""
+---
+
+The GovPress business unit works flexibly, depending on the needs of our clients. We are organised into a number of teams, which work on client projects and work paid for on retainer.
+We are not dogmatic about exactly who works on which piece of work, but this document describes our expected way of working throughout the year.
+
+## Sprinting teams
+
+Sprinting teams work on longer (>2 weeks) projects which clients pay for separately (i.e. not via retainers). Sprinting teams are not static, we create them when we have work available and each team is chosen to meet the needs of the work.
+
+Note that sprinting teams will often be small. Where architecture and code review become a burden, the team may use pair or mob programming to speed up delivery.
+
+Team members will be scheduled for work on this team, before each project begins. These schedules will be coordinated by the Delivery Lead.
+
+### The team
+
+This team:
+
+* Is led by a Tech Lead (usually the Projects Lead Developer) and Delivery Lead
+* Is formed around the needs of each project, but each developer should work in a sprinting team over the course of a year
+* Usually includes one front-end developer or designer
+* Only includes the GovPress Ops Engineer and Platform Tech Lead when necessary
+* Uses the `#dxw-govpress-sprinting-teams` Slack channel for coordination
+
+### Cadence
+
+Each project in this team will run roughly like a Scrum project:
+
+* Some discovery work is done before the project starts and led by the Delivery Lead or Head of Unit
+* Projects start with one (or more) days of technical preparation time with only the Tech Lead working on the project, while other team members help on Support
+* Iterations happen in 2 week sprints
+* Ceremonies are run by the Delivery Lead and will include both client-facing stand-ups and time for the team to synchronise without the client
+* The Delivery Lead checks in with the client in the middle of sprints (outside of stand-ups)
+* Projects usually include a retrospective with client at the end of the project
+* We'd hope to allow sprinting team members 1 day of dxw time every 2 weeks, even on a longer-running project, and we aim to ensure that team members have 1 dxw day at end of each project, if their next piece of work is also in a sprinting team
+
+## Maintenance and support team
+
+This team works on tasks which are paid for via support and maintenance retainers. Some members of the team may work on tasks that are paid for separately, but last much less than a 2 week Scrum sprint.
+
+Where we have larger pieces of work that require several developers or longer periods of time (including site migrations), we create a new sprinting team, led by one of the Tech Leads.
+
+Where we have larger pieces of work (>1day) that are too small for a sprinting team, wherever possible these are taken on by a minimum of two developers, one of which will usually be a Tech Lead.
+
+The team takes overall responsibility for the maintenance of our products and internal tooling, including creating new tools and processes that help to keep our workflows efficient. However, everyone is encouraged and expected to resolve maintenance issues when they come across them, or raise Trello cards for this team where tasks are too large to be completed in the course of other work.
+
+### The team
+
+This Maintenance and Support team:
+
+* Is usually led by the Engineering Manager / Delivery Lead
+* Always includes support staff and account managers
+* Always includes 2nd line support rota developer. Each developer will take on this role over the course of a quarter, including Tech Leads
+* Always includes the team Ops Engineer and Platform Technology Lead
+* Uses the `#dxw-govpress-maintenance-and-support` Slack channel for coordination
+
+### Cadence
+
+There is no expectation that this team works in sprints, or follows Scrum. The cadence of this team is very loosely based on [eXtreme Programming (XP)](https://en.wikipedia.org/wiki/Extreme_programming):
+
+* Planning happens weekly, on a Tuesday morning, and looks no further than the current week, since we don’t know what work will come through the support desk
+* Ceremonies are usually run by the Delivery Lead
+* The team holds a retrospective at the end of every month
+* Each week the team will work from a Trello board which will be cleared at the end of the week
+* A longer term Trello board holds a larger backlog of stories to be considered for scheduling each week
+* Stand-ups may use both the Trello board and Zendesk views
+* This team will have dxw days every two weeks, with a show & tell at the end of the day
+
+## GovPress-wide meetings and events
+
+The whole GovPress team comes together for regular catch-ups, including:
+
+* Weekly social time on Friday mornings
+* Monthly show & tells
+* Monthly developer training sessions
+* Quarterly away days, usually held on-site

--- a/src/staff-handbook/leave/holiday.md
+++ b/src/staff-handbook/leave/holiday.md
@@ -12,7 +12,9 @@ The holiday year at dxw runs between 1st January and 31st December, and you are 
 1. Discuss the dates with your team and delivery lead
 
    This gives them a chance to manage any impact it might have on the wider team
-   and the project.
+   and the project. Colleagues in GovPress should do this via the `#dxw-govpress-holiday-plans`
+   Slack channel.
+
 2. Request the holiday through BreatheHR
 
    We use BreatheHR to track who's off and when, so we can plan for it. Your


### PR DESCRIPTION
This follows some work we did earlier this year to move away from the 'squad' model to a more flexible approach to organising the unit.