### PR TITLE
Link to new guidance

### DIFF
--- a/src/user-research/choosing-and-using-research-methods.md
+++ b/src/user-research/choosing-and-using-research-methods.md
@@ -1,13 +1,15 @@
 ---
 title: Choosing and using research methods
 related_order: 70
-last_reviewed_at: ""
+last_reviewed_at: 2024-01-29T11:17:41.859Z
 ---
 Our fourth research principle is to [be methodical, but not rigid](/user-research/#user-research-principles). At dxw, we don’t have a fixed set of approved research methods. But when we [plan our research](https://playbook.dxw.com/user-research/creating-and-using-research-plans/), we do need to choose appropriate methods for the context and apply them well.
 
 We prefer tried and trusted methods that can provide strong evidence and reliable answers to our questions, for the least time, effort and cost.
 
-And we always consider a team’s level of experience with user research. So we may prefer simpler methods like interviews and usability testing that the team can easily understand and join in with.
+And we want to make sure that the way we use these methods is [inclusive and accessible](/user-research/making-research-activities-inclusive-and-accessible/) for our participants and our colleagues.
+
+We also consider a team’s level of experience with user research. So we may prefer simpler methods like interviews and usability testing that the team can easily understand and join in with.
 
 This guide lists our favourite books, articles and videos on the different research methods we use. In future we aim to add links to any tools and templates we have created, along with good examples from previous projects.
 
@@ -31,13 +33,13 @@ At dxw, we follow human centred design practices to [start with people and their
 
 Interviews are a flexible way to learn more about different types of users, including their circumstances, previous experiences, motivations and needs from services.
 
-Choose interviews when:
+We choose interviews when:
 
-* your research is broad and you don’t yet know which topics will be most relevant or which questions will be most useful
+* our research is broad and we don’t yet know which topics will be most relevant or which questions will be most useful
 * the subject is complicated, will require some explanation and participants are likely to give you long and detailed answers
-* you want the chance to ask follow up questions to fully explore and better understand what participants tell you
+* we want the chance to ask follow up questions to fully explore and better understand what participants tell us
 
-You can combine interviews with usability testing, by talking to participants to understand previous experiences and current use, before asking them to try out a prototype or service.
+We sometimes combine interviews with usability testing, by talking to participants to understand previous experiences and current use, before asking them to try out a prototype or service.
 
 ### Recommended guidance
 
@@ -52,10 +54,10 @@ Contextual research means visiting people in their everyday environment (like th
 
 Watching someone complete a task in familiar surroundings with their own equipment (and usual distractions) can help us better understand how they use an existing service, what does and doesn’t work well for them, and what they might need from a future service.
 
-Choose contextual research and observation when:
+We choose contextual research and observation when:
 
-* you want to see how people do things in a real-life context using their own data, documents and devices
-* you want the chance to ask questions about the barriers or problems people experience, and the different ways they try to overcome them
+* we want to see how people do things in a real-life context using their own data, documents and devices
+* we want the chance to ask questions about the barriers or problems people experience, and the different ways they try to overcome them
 
 ### Recommended guidance
 
@@ -71,12 +73,12 @@ Experience and journey maps provide a visual representation of what users do, th
 
 There is no precise distinction between the two kinds of maps. But experience maps most often cover a person’s entire experience of a whole life event, and may include their interactions with a number of services. While journey maps tend to cover their path through a particular service.
 
-Choose experience mapping when you want to:
+We choose experience mapping when we want to:
 
 * create a visual representation of all the things people go through and their experience of those activities
 * focus on a person’s entire experience rather than their interaction with one service
 
-Choose journey mapping when you want to:
+We choose journey mapping when we want to:
 
 * create a time ordered visual representation of the larger stages and individual steps people go through when interacting with a service
 * show the different people who do, or are involved in, each step, often with swimlanes
@@ -100,17 +102,17 @@ Either way, profiles and personas should focus on peoples’ roles and motivatio
 
 When creating personas we do not give them names, photos, ages or other demographic details that can create unintended bias in readers.
 
-Choose profiles when:
+We choose profiles when:
 
-* you want to describe groups of people who play different roles within a service (such as patients, carers, doctors and pharmacists, in a service about prescriptions)
+* we want to describe groups of people who play different roles within a service (such as patients, carers, doctors and pharmacists, in a service about prescriptions)
 
-Choose profiles or personas when:
+We choose profiles or personas when:
 
-* you want to describe different groups of people whose circumstances strongly influence their interactions and needs from a service (such as single people, couples and families, in a service about housing)
+* we want to describe different groups of people whose circumstances strongly influence their interactions and needs from a service (such as single people, couples and families, in a service about housing)
 
-Choose personas when:
+We choose personas when:
 
-* representing a group with a realistic character will present what you’ve learned about that group in a more engaging way
+* representing a group with a realistic character will present what we’ve learned about that group in a more engaging way
 
 ### Recommended guidance
 
@@ -123,18 +125,18 @@ Choose personas when:
 
 Interactive workshops with small groups can be an effective method for user research.
 
-They can help you learn more about the things that actual or likely users do, how they do them, how they think and make decisions, and how they feel about their experiences.
+They can help us learn more about the things that actual or likely users do, how they do them, how they think and make decisions, and how they feel about their experiences.
 
-Choose workshops when you want to:
+We choose workshops when we want to:
 
 * see how different people, such as colleagues in different roles, or parents and children, work together to make a decision or to get something done
 * get a more detailed understanding of people who’ve had a similar experience
 
-You can also do workshops with stakeholders, teams and subject matter experts, as a good first step to get an overview of a new area and build trust in preparation for more detailed research.
+We also do workshops with stakeholders, teams and subject matter experts, as a good first step to get an overview of a new area and build trust in preparation for more detailed research.
 
-Group workshops may not be appropriate when researching very sensitive subjects, or with people in vulnerable contexts, who may want more privacy and confidentiality.
+Group workshops may not be appropriate when [researching very sensitive subjects](/user-research/doing-research-safely/), or with people in vulnerable contexts, who may want more privacy and confidentiality.
 
-Also bear in mind that you don’t get twice as many findings by inviting twice as many people to a session. If there’s nothing to gain from having several participants together, you should run individual research sessions using methods such as interviews, contextual observation or experience mapping.
+We also bear in mind that we don’t get twice as many findings by inviting twice as many people to a session. If there’s nothing to gain from having several participants together, we run individual research sessions using methods such as interviews, contextual observation or experience mapping.
 
 ### Recommended guidance
 
@@ -147,9 +149,9 @@ Also bear in mind that you don’t get twice as many findings by inviting twice 
 
 With surveys we ask a defined group of people a set of questions, and analyse their answers to produce findings.
 
-So choose surveys when you need quantitative data (numbers), know what questions you want to ask, and know who you want to ask.
+We choose surveys when we need quantitative data (numbers), know what questions we want to ask, and know who we want to ask.
 
-If you are not sure about any of those things, maybe you don’t yet know which questions are important, or who it’s important to ask, then start with other methods like interviews. And consider doing a survey later, when things are clearer.
+If we’re not sure about any of those things - maybe we don’t yet know which questions are important, or who it’s important to ask - then we start with other methods like interviews. And consider doing a survey later, when things are clearer.
 
 ### Recommended guidance
 
@@ -168,11 +170,11 @@ Through concept testing we can learn more about:
 * how well the designs might achieve the intended outcome
 * potential improvements to our designs
 
-Choose concept testing when you want to evaluate your designs, but do not yet have a properly interactive prototype or working service that people can try out for real. Concept testing is particularly useful when you want to quickly explore several alternative design ideas.
+We choose concept testing when we want to evaluate our designs, but do not yet have a properly interactive prototype or working service that people can try out for real. Concept testing is particularly useful when you want to quickly explore several alternative design ideas.
 
-You can run concept testing with individual participants or with small groups, when conversations between participants can bring out additional points.
+We can run concept testing with individual participants, or with small groups, when conversations between participants can bring out additional points.
 
-You can combine concept testing with initial interviews to understand more about a participant’s circumstances, experiences and needs. And follow up with workshop activities to iterate the concepts.
+We often combine concept testing with initial interviews to understand more about a participant’s circumstances, experiences and needs. And follow up with workshop activities to iterate the concepts.
 
 ### Recommended guidance
 
@@ -184,11 +186,11 @@ You can combine concept testing with initial interviews to understand more about
 
 In content research we are focussed on how people find, understand, interact with and act on different kinds of content about and within services.
 
-Choose card sorting to explore the associations people have between different words and concepts, and how people see things fitting into groups or categories.
+We choose card sorting to explore the associations people have between different words and concepts, and how people see things fitting into groups or categories.
 
-Choose tree testing to test how participants might navigate a proposed information architecture.
+We choose tree testing to test how participants might navigate a proposed information architecture.
 
-Choose highlighter and similar tests to see how well participants understand and can act on content, like guidance, letters or notifications.
+We choose highlighter and similar tests to see how well participants understand and can act on content, like guidance, letters or notifications.
 
 ### Recommended guidance
 
@@ -205,15 +207,15 @@ Choose highlighter and similar tests to see how well participants understand and
 
 ## Usability testing
 
-Usability testing is where you ask participants to try to complete specific tasks using your service.
+Usability testing is where we ask participants to try to complete specific tasks using our service.
 
 Usability testing can be moderated or unmoderated.
 
-In moderated usability testing, you will be present during the session, either in person or online. You will describe the tasks you want participants to try. And will usually ask them to ‘think aloud’ as they move through the service to help you understand what they are doing, thinking and feeling.
+In moderated usability testing, we are present during the session, either in person or online. We describe the tasks we want participants to try. And will usually ask them to ‘think aloud’ as they move through the service to help us understand what they are doing, thinking and feeling.
 
-In unmoderated usability testing, you will provide participants with the tasks and access to the service you want to test. And participants complete the tasks on their own. You may record the unmoderated tests and ask participants to think aloud for the recording, or capture only web page analytics and the data entered.
+In unmoderated usability testing, we provide participants with the tasks we want them to try, and access to the service we want to test. And participants complete the tasks on their own. We may record the unmoderated tests and ask participants to think aloud for the recording, or capture only web page analytics and the data entered.
 
-Choose usability testing when you have an existing service, a working prototype, or a newly built service, and want to know how well it works for likely users.
+We choose usability testing when we have an existing service, a working prototype, or a newly built service, and want to know how well it works for likely users.
 
 ### Recommended guidance
 

--- a/src/user-research/choosing-and-using-research-methods.md
+++ b/src/user-research/choosing-and-using-research-methods.md
@@ -9,7 +9,7 @@ We prefer tried and trusted methods that can provide strong evidence and reliabl
 
 And we make sure to use these methods in ways that are [inclusive and accessible](/user-research/making-research-activities-inclusive-and-accessible/), and [safe for our participants and ourselves](/user-research/doing-research-safely/).
 
-We also consider a team’s level of experience with user research. So we may prefer simpler methods like interviews and usability testing that the team can easily understand and join in with.
+We also consider a team’s level of experience with user research. So we may prefer simpler methods like interviews and usability testing that the team can easily understand and get involved in.
 
 This guide lists our favourite books, articles and videos on the different research methods we use. In future we aim to add links to any tools and templates we have created, along with good examples from previous projects.
 
@@ -134,7 +134,7 @@ We choose workshops when we want to:
 
 We also do workshops with stakeholders, teams and subject matter experts, as a good first step to get an overview of a new area and build trust in preparation for more detailed research.
 
-Group workshops may not be appropriate when [researching very sensitive subjects](/user-research/doing-research-safely/), or with people in vulnerable contexts, who may want more privacy and confidentiality.
+When [researching very sensitive subjects](/user-research/doing-research-safely/), we understand that some participants may want more privacy and confidentiality than a group workshop can provide.
 
 We also bear in mind that we don’t get twice as many findings by inviting twice as many people to a session. If there’s nothing to gain from having several participants together, we run individual research sessions using methods such as interviews, contextual observation or experience mapping.
 

--- a/src/user-research/choosing-and-using-research-methods.md
+++ b/src/user-research/choosing-and-using-research-methods.md
@@ -1,7 +1,7 @@
 ---
 title: Choosing and using research methods
 related_order: 70
-last_reviewed_at: 2024-01-29T11:17:41.859Z
+last_reviewed_at: 2024-01-29
 ---
 Our fourth research principle is to [be methodical, but not rigid](/user-research/#user-research-principles). At dxw, we don’t have a fixed set of approved research methods. But when we [plan our research](https://playbook.dxw.com/user-research/creating-and-using-research-plans/), we do need to choose appropriate methods for the context and apply them well.
 

--- a/src/user-research/choosing-and-using-research-methods.md
+++ b/src/user-research/choosing-and-using-research-methods.md
@@ -1,13 +1,13 @@
 ---
 title: Choosing and using research methods
 related_order: 70
-last_reviewed_at: 2024-01-29
+last_reviewed_at: 2024-01-29T11:17:41.859Z
 ---
 Our fourth research principle is to [be methodical, but not rigid](/user-research/#user-research-principles). At dxw, we don’t have a fixed set of approved research methods. But when we [plan our research](https://playbook.dxw.com/user-research/creating-and-using-research-plans/), we do need to choose appropriate methods for the context and apply them well.
 
 We prefer tried and trusted methods that can provide strong evidence and reliable answers to our questions, for the least time, effort and cost.
 
-And we want to make sure that the way we use these methods is [inclusive and accessible](/user-research/making-research-activities-inclusive-and-accessible/) for our participants and our colleagues.
+And we make sure to use these methods in ways that are [inclusive and accessible](/user-research/making-research-activities-inclusive-and-accessible/), and [safe for our participants and ourselves](/user-research/doing-research-safely/).
 
 We also consider a team’s level of experience with user research. So we may prefer simpler methods like interviews and usability testing that the team can easily understand and join in with.
 


### PR DESCRIPTION
Add a link to the new guidance on making research inclusive and accessible.
Be consistent with other guides in using we rather than you.