### PR TITLE
Update guidance for current practice

### DIFF
--- a/src/user-research/taking-notes-and-recording-research-sessions.md
+++ b/src/user-research/taking-notes-and-recording-research-sessions.md
@@ -1,7 +1,7 @@
 ---
 title: Taking notes and recording research sessions
 related_order: 180
-last_reviewed_at: ""
+last_reviewed_at: 2024-01-29T13:31:14.454Z
 ---
 To capture what happens in our research sessions we take notes and photos, make
 audio, video and screen recordings, and take copies of paperwork and other
@@ -21,116 +21,103 @@ Here we provide additional, specific guidance for researchers at dxw.
 
 ## Good practices to follow
 
-1. **Capture only what you need and have consent for**
+### Capture only what we need and have consent for
 
-   Good user research practice, and good privacy practice, is to capture only
-   the data you believe you need. For example, don’t make a screen or video
-   recording, ‘just in case’, if you’ll only ever need a transcript of what the
-   participant says.
+We follow good user research practice, and good privacy practice, by capturing only the data we believe we need. For example, not making a video recording, ‘just in case’, if we’ll only ever need a transcript of what the participant says.
 
-   Make sure that anything you capture during a session is covered by the
-   consent you’ve collected. If a participant changes their mind about what they
-   consent to, be prepared to not make, or to delete recordings you no longer
-   have consent for.
-2. **Do not use your personal devices**
+And we make sure that anything we capture during a session is covered by the consent we’ve collected. If a participant changes their mind about what they consent to, we are prepared to not make, or to delete recordings we no longer have consent for.
 
-   Always use a dxw provided device, rather than your personal device, when
-   taking notes and photos, or making recordings.
+### Keep your notes and recordings secure
 
-   Using our own devices in research means that personal data about research
-   participants can be mixed into our personal data stores, like cloud photo
-   libraries. And also runs the risk of participants, client staff and
-   colleagues seeing our personal messages and images.
-3. **Keep your notes and recordings secure**
+We [take care of research data](/user-research/taking-care-of-research-data/) to protect our participants’ privacy.
 
-   As soon as possible after the session, transfer any notes and recordings from
-   paper and other devices to your dxw provided laptop. And from your laptop to
-   the dxw Google Drive or to the client’s research store.
+As soon as possible after a session, we transfer any notes and recordings from paper and other devices to our dxw provided laptop. And from there to the dxw Google Drive, or to the client’s research store.
 
-   Keep only anonymised notes, quotes and images in tools like Miro and Trello.
-4. **Have a fall back**
+We make sure the files
+[have good names](/user-research/taking-care-of-research-data/#identifying-research-data-clearly),
+so we can find them and delete them when we need to.
 
-   The one certainty in user research is that things go wrong. So make sure you
-   have other options to capture what you need.
+We keep only anonymised notes, quotes and images in tools like Miro and Trello.
 
-   For example:
+### Do not use our personal devices
 
-   * The participant may decide they don’t want to be recorded in a particular
-     way, so be prepared to switch from video to an audio-only recording, or to
-     just take notes
-   * Your preferred device, app or service may not be working properly, so have
-     an alternative like a paper notebook
-   * Your note taker, assistant or observer may not be able to join the session,
-     so be prepared to take notes and recordings yourself
+We always use a dxw provided device, rather than our personal device, when taking notes and photos, or making recordings.
 
-   Note that if the participant refuses all recording, including note taking,
-   you may want to abandon the session.
+Using our own devices in research means that personal data about research participants can be mixed into our personal data stores, like cloud photo libraries. And also runs the risk of participants, client staff and colleagues seeing our personal messages and images.
 
-## Using your dxw provided laptop
+### Have a fall back
 
-Whenever possible, use your dxw provided laptop for taking notes and making
-recordings. Our laptops have encrypted drives and we follow good security
-policies.
+The one certainty in user research is that things go wrong. So we make sure we have other options to capture what we need.
 
-With your laptop you can:
+For example:
+
+* The participant may decide they don’t want to be recorded in a particular way, so we are prepared to switch from video to an audio-only recording, or to just take notes
+* Our preferred device, app or service may not be working properly, so we have an alternative like a paper notebook
+* Our note taker, assistant or observer may not be able to join the session, so we are prepared to take notes and recordings ourselves
+
+If our participant refuses all recording, including note taking, we accept that we might need to abandon the session.
+
+## Using our dxw provided laptop
+
+Whenever possible, we use our dxw provided laptop for taking notes and making recordings. Our laptops have encrypted drives and we follow good security policies.
+
+With our laptop we can:
 
 * capture notes to a local file or a Google Sheet
 * record audio using a microphone and the Voice Memos or Quicktime apps
 * record video using an external camera and Quicktime
-* record your laptop screen using Quicktime or Screenshot
+* record our laptop screen using Quicktime or Screenshot
 
-If research participants might use your laptop or see your screen during a
-research session, it’s a good idea to create a separate ‘research’ user account
-on your laptop with things like notifications and browser autofill turned off.
-
-## Using a dxw provided handheld device
-
-Use a dxw provided handheld device, rather than own phone or tablet, to take
-photos and short videos during interviews, visits and workshops.
-
-Remember to delete the photos and recordings from the device once you have
-transferred them to your laptop or to Google Drive.
+If research participants might use our laptop or see our screen during a research session, we might create a separate ‘research’ user account
+on our laptop with things like notifications and browser autofill turned off.
 
 ## Using the notes template
 
 We have a
 [template for a Google Sheet](https://drive.google.com/open?id=1r6xtVgHBFTDxbFGSqk3wXFDy_5JDwkBpGBHibnLKuwM)
-you can use to take notes during a research session.
+we can use to take notes during a research session.
 
-You can make a copy of the sheet for each research session, or make a copy for
-each batch of research and create tabs within the sheet for each research
-session.
+We can make a copy of the sheet for each research session, or make a copy for each batch of research and create tabs within the sheet for each research session.
+
+## Using recordings from video calls
+
+Our preferred service for video calls is
+[Google Meet](https://meet.google.com/).
+We often use it to run and record activities like usability tests, where we ask a participant to share their screen.
+
+We make sure to transfer recordings from the Meet Recordings folder in our personal Google Drive, and
+[give them a good name](/user-research/taking-care-of-research-data/#identifying-research-data-clearly).
+
+Depending on the client, we may need to use their preferred video conferencing service. If the service stores recordings ‘in the cloud’, we make sure to transfer and rename the video, and delete it from the service.
+
+## Using online whiteboards
+
+We often use online whiteboards like Miro and Trello to capture information during
+[individual and group research sessions](/user-research/choosing-and-using-research-methods/#workshops-and-group-activities).
+
+And we often transfer research data to online whiteboards to support [group analysis](/user-research/choosing-and-using-analysis-and-synthesis-methods/).
+
+We avoid capturing personally identifiable information about participants in online whiteboards. If we capture any sensitive information make sure to anonymise or delete it.
 
 ## Using sticky notes and paper worksheets
 
-We often use sticky notes and paper worksheets to capture information during
-research sessions, for example when
+We often use sticky notes and paper worksheets to capture information during research sessions, for example when
 [researching users’ experiences](https://www.gov.uk/service-manual/user-research/researching-user-experiences).
 
-Design paper worksheets, and give people advice on
+And we often design paper worksheets, and give people advice on
 [writing sticky notes](https://www.gov.uk/service-manual/user-research/taking-notes-and-recording-user-research-sessions#using-sticky-notes),
-so you can easily use the information recorded.
+so we can easily use the information recorded.
 
-Avoid capturing personally identifiable information about participants on sticky
-notes or paper. If you capture any sensitive information on sticky notes or
-paper, make sure to use a shredder to dispose of it.
+We avoid capturing personally identifiable information about participants on sticky notes or paper. If we capture any sensitive information on sticky notes or paper, we tear it up, or use a shredder, to dispose of it.
 
-Use a dxw provided phone or tablet, rather than your personal device, to capture
-the contents of sticky notes and paper worksheets.
+And we use a dxw provided device, rather than our personal device, to capture the contents of sticky notes and paper worksheets.
 
-## Using a video conferencing service
+## Using a dxw provided handheld device
 
-Our preferred service for recording remote screen sharing sessions is
-[GoToMeeting](https://docs.google.com/document/d/1KiaXHr-VCX8T6K9YWPnmHHiAChJda_gH4av03N4pDrg/).
-Setup GoToMeeting so that the recorded video is saved onto your dxw provided
-laptop. And then transfer the video to Google Drive as soon as possible.
+We always use a dxw provided handheld device, rather than our own phone or tablet, to take photos and short videos during interviews, visits and workshops.
 
-Depending on the client, we may need to use their preferred video conferencing
-service. If the service stores recordings ‘in the cloud’, make sure to download
-the video as soon as possible and delete it from the service.
+We remember to delete the photos and recordings from the device once we have transferred them to our laptop or to Google Drive.
 
 ## Using third-party facilities
 
-If you are using a third party facility like a usability lab, transfer any
-recordings made by the lab to your dxw provided laptop as soon as possible after
-the sessions are complete.
+When we are using a third party facility like a usability lab, we transfer any recordings made by the lab to our dxw provided laptop, and from there to Google Drive, as soon as possible after the sessions are complete.

--- a/src/user-research/taking-notes-and-recording-research-sessions.md
+++ b/src/user-research/taking-notes-and-recording-research-sessions.md
@@ -3,13 +3,9 @@ title: Taking notes and recording research sessions
 related_order: 180
 last_reviewed_at: 2024-01-29T13:31:14.454Z
 ---
-To capture what happens in our research sessions we take notes and photos, make
-audio, video and screen recordings, and take copies of paperwork and other
-material that participants use or refer to.
+To capture what happens in our research sessions we take notes and photos, make audio, video and screen recordings, and take copies of paperwork and other material that participants use or refer to.
 
-We use these notes, photos and recordings during analysis to make sure we
-produce valid findings. And we use extracted quotes, images and clips to
-illustrate the findings we share.
+We use these notes, photos and recordings during analysis to make sure we produce valid findings. And we use extracted quotes, images and clips to illustrate the findings we share.
 
 There is good guidance on
 [Taking notes and recording user research sessions](https://www.gov.uk/service-manual/user-research/taking-notes-and-recording-user-research-sessions)
@@ -88,7 +84,7 @@ We often use it to run and record activities like usability tests, where we ask 
 We make sure to transfer recordings from the Meet Recordings folder in our personal Google Drive, and
 [give them a good name](/user-research/taking-care-of-research-data/#identifying-research-data-clearly).
 
-Depending on the client, we may need to use their preferred video conferencing service. If the service stores recordings ‘in the cloud’, we make sure to transfer and rename the video, and delete it from the service.
+Depending on the client, we may need to use their preferred video conferencing service. If the service keeps recordings in its own cloud storage, we make sure to transfer and rename the video, and delete it from the service.
 
 ## Using online whiteboards
 
@@ -97,12 +93,12 @@ We often use online whiteboards like Miro and Trello to capture information duri
 
 And we often transfer research data to online whiteboards to support [group analysis](/user-research/choosing-and-using-analysis-and-synthesis-methods/).
 
-We avoid capturing personally identifiable information about participants in online whiteboards. If we capture any sensitive information make sure to anonymise or delete it.
+We avoid capturing personally identifiable information about participants in online whiteboards. If we do capture any sensitive information, we make sure to anonymise or delete it.
 
 ## Using sticky notes and paper worksheets
 
 We often use sticky notes and paper worksheets to capture information during research sessions, for example when
-[researching users’ experiences](https://www.gov.uk/service-manual/user-research/researching-user-experiences).
+[researching users’ experiences](/user-research/choosing-and-using-research-methods/#experience-and-journey-mapping).
 
 And we often design paper worksheets, and give people advice on
 [writing sticky notes](https://www.gov.uk/service-manual/user-research/taking-notes-and-recording-user-research-sessions#using-sticky-notes),

--- a/src/user-research/taking-notes-and-recording-research-sessions.md
+++ b/src/user-research/taking-notes-and-recording-research-sessions.md
@@ -51,9 +51,9 @@ For example:
 
 * The participant may decide they don’t want to be recorded in a particular way, so we are prepared to switch from video to an audio-only recording, or to just take notes
 * Our preferred device, app or service may not be working properly, so we have an alternative like a paper notebook
-* Our note taker, assistant or observer may not be able to join the session, so we are prepared to take notes and recordings ourselves
+* Our note taker, assistant or observer may not be able to join the session, so we are prepared to take notes and make recordings ourselves
 
-We might decide to cancel a session if note taking, recording or data collection is not possible, and it is essential for the research activity.
+We can decide to cancel a session if essential note taking, recording or other data collection is not possible. Whether because of technical problems, or because the participant does not consent.
 
 ## Using our dxw provided laptop
 
@@ -66,7 +66,7 @@ With our laptop we can:
 * record video using an external camera and Quicktime
 * record our laptop screen using Quicktime or Screenshot
 
-If research participants might use our laptop or see our screen during a research session, we might create a separate ‘research’ user account
+If research participants will use our laptop or see our screen during a research session, we might create a separate ‘research’ user account
 on our laptop with things like notifications and browser autofill turned off.
 
 ## Using the notes template

--- a/src/user-research/taking-notes-and-recording-research-sessions.md
+++ b/src/user-research/taking-notes-and-recording-research-sessions.md
@@ -23,7 +23,7 @@ We follow good user research practice, and good privacy practice, by capturing o
 
 And we make sure that anything we capture during a session is covered by the consent we’ve collected. If a participant changes their mind about what they consent to, we are prepared to not make, or to delete recordings we no longer have consent for.
 
-### Keep your notes and recordings secure
+### Keep our notes and recordings secure
 
 We [take care of research data](/user-research/taking-care-of-research-data/) to protect our participants’ privacy.
 
@@ -53,7 +53,7 @@ For example:
 * Our preferred device, app or service may not be working properly, so we have an alternative like a paper notebook
 * Our note taker, assistant or observer may not be able to join the session, so we are prepared to take notes and recordings ourselves
 
-If our participant refuses all recording, including note taking, we accept that we might need to abandon the session.
+We might decide to cancel a session if note taking, recording or data collection is not possible, and it is essential for the research activity.
 
 ## Using our dxw provided laptop
 
@@ -86,7 +86,7 @@ We often use it to run and record activities like usability tests, where we ask 
 We make sure to transfer recordings from the Meet Recordings folder in our personal Google Drive, and
 [give them a good name](/user-research/taking-care-of-research-data/#identifying-research-data-clearly).
 
-Depending on the client, we may need to use their preferred video conferencing service. If the service keeps recordings in its own cloud storage, we make sure to transfer and rename the video, and delete it from the service.
+Depending on the client, we may need to use their preferred video call service. If the service keeps recordings in its own cloud storage, we make sure to transfer and rename the video, and delete it from the service.
 
 ## Using online whiteboards
 

--- a/src/user-research/taking-notes-and-recording-research-sessions.md
+++ b/src/user-research/taking-notes-and-recording-research-sessions.md
@@ -37,7 +37,9 @@ We keep only anonymised notes, quotes and images in tools like Miro and Trello.
 
 ### Do not use our personal devices
 
-We always use a dxw provided device, rather than our personal device, when taking notes and photos, or making recordings.
+We always use a
+[dxw provided device]](#using-a-dxw-provided-handheld-device),
+rather than our personal device, when taking notes and photos, or making recordings.
 
 Using our own devices in research means that personal data about research participants can be mixed into our personal data stores, like cloud photo libraries. And also runs the risk of participants, client staff and colleagues seeing our personal messages and images.
 
@@ -100,13 +102,15 @@ We avoid capturing personally identifiable information about participants in onl
 We often use sticky notes and paper worksheets to capture information during research sessions, for example when
 [researching users’ experiences](/user-research/choosing-and-using-research-methods/#experience-and-journey-mapping).
 
-And we often design paper worksheets, and give people advice on
+We give people advice on
 [writing sticky notes](https://www.gov.uk/service-manual/user-research/taking-notes-and-recording-user-research-sessions#using-sticky-notes),
 so we can easily use the information recorded.
 
-We avoid capturing personally identifiable information about participants on sticky notes or paper. If we capture any sensitive information on sticky notes or paper, we tear it up, or use a shredder, to dispose of it.
+We avoid capturing personally identifiable information about participants on sticky notes or paper. If we do capture any sensitive information, we tear it up, or use a shredder, to dispose of it.
 
-And we use a dxw provided device, rather than our personal device, to capture the contents of sticky notes and paper worksheets.
+And we
+[use a dxw provided device](#using-a-dxw-provided-handheld-device),
+rather than our personal device, to capture the contents of sticky notes and paper worksheets.
 
 ## Using a dxw provided handheld device
 


### PR DESCRIPTION
Reference Google Meet rather than GoToMeeting as our preferred video call service.
Be consistent about we rather than you.
Re-order sections to cover the most common situations first.
Add more links to other guidance.