### PR TITLE
Install bundler after installing ruby version

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -28,6 +28,7 @@ if [ -f .ruby-version ]; then
     brew upgrade ruby-build
     rbenv install
     rbenv rehash
+    gem install bundler
   fi
 fi
 


### PR DESCRIPTION
Resolving an issue on a new setup where bundler is not found for the current version. See [GitHub issue](https://github.com/rbenv/rbenv/issues/285#issuecomment-11843413)