### PR TITLE
Add govpress junior dev development plan

### DIFF
--- a/src/govpress-unit/apprentice-developer-plan.md
+++ b/src/govpress-unit/apprentice-developer-plan.md
@@ -1,5 +1,5 @@
 ---
-title: Apprentice developer development plan
+title: Development plan - Apprentice developers
 last_reviewed_at: ""
 ---
 

--- a/src/govpress-unit/apprentice-developer-plan.md
+++ b/src/govpress-unit/apprentice-developer-plan.md
@@ -127,7 +127,7 @@ and working with the client support team. During this time, you’ll help triage
 tickets that come in, carry out maintenance tasks, and solve issues that come up.
 You will do this with the support of members of that team.
 
-### Months 12-13: Technical OPerations and delivery rotation
+### Months 12-13: Technical Operations and delivery rotation
 
 It is important for all developers to understand what happens to code once it is
 deployed to a live environment, and the challenges involved in securing deployments,

--- a/src/govpress-unit/junior-developer-plan.md
+++ b/src/govpress-unit/junior-developer-plan.md
@@ -1,0 +1,118 @@
+---
+title: Junior developer development plan
+last_reviewed_at: ""
+---
+
+## High level principles and goals
+
+Junior developers are hired from a variety of different backgrounds, and what you
+did before you were hired will partly determine how we structure your time with us.
+If you have worked with us as an Apprentice Developer we would expect you to be able
+to contribute to billable client work immediately, because you will have already done
+this as part of your apprenticeship. However, if you have previously completed a bootcamp
+or degree, or you were self-taught, we would expect that your first six months with
+us would be spent learning about our technology stack and development processes.
+
+Consequently, a Junior Developer who has been promoted from an Apprentice level
+role would directly follow the development plan described here, but a Junior
+Developer from a different background would spend their first year roughly following
+the Apprentice Developer Development Plan and the next year following this plan.
+We expect Juniors will usually be ready to apply for a promotion to a Developer
+level role after two years. Of course, each developer is different, and the exact
+path you take will be agreed with your line manager as you go along, so these are
+principles, not policies.
+
+When we hire a Junior Developer, of course we want you to add value to dxw and our
+clients, but we also know that this is a crucial time for your own professional
+development. With that in mind, we want to structure your development plan with
+these principles in mind:
+
+* You will already be capable of writing code and contributing to development teams and this is an opportunity to deepen your expertise and create the foundation for a long term career in technology.
+* We expect you will need more time to develop competence in the 'cross-cutting concerns' that are important in creating websites in GovPress. In particular, we want to ensure that you have a working understanding of: accessibility, security and privacy, testing, performance and web hosting. You are not expected to become an 'expert' in any of these areas (unless you want to) but by the time you are ready for a Developer role, you should be able to create an accessible, secure, well-tested, performant website which is ready for deployment to a modern hosting platform, with little support from the wider team.
+* You will be a full member of the GovPress team and have the same benefits and responsibilities as your colleagues.
+
+During your time as a Junior Developer, we will ensure that you have the following
+experiences:
+
+* You will meet some of our clients, in a variety of contexts, and learn about how we work with them.
+* When we have new projects starting, you will assist with requirements gathering.
+* You will contribute to our regular meetings, where we coordinate our work (e.g. planning, stand-ups, retrospectives) and other team rituals.
+* You will contribute to accessibility reviews, security reviews and our incident response process.
+* You will review code written by other colleagues.
+* You will work on support, responding to client requests and resolving tickets.
+* You will work with our developers, to implement and improve our client sites.
+  Your work here will become increasingly independent over time, but we expect
+  that your client code will be shipped to production.
+* You will spend some time maintaining our internal tools and systems. This work is
+  [essential in making our day-to-day workflow efficient enough to support more than 100 websites in a cost-efficient manner](https://www.dxw.com/2022/07/govpress-tools-automation-and-scaling-our-wordpress-offering/),
+  as well as providing extra security and features to our customers.
+* You will have some self-directed learning and development time. Some of this time
+  should be spent on activities that you choose yourself, but initially this time
+  should be agreed with your line manager and based on the projects described below.
+* You will have the opportunity to join our
+  [on-call rota](https://playbook.dxw.com/tech/support-and-on-call/#being-on-call).
+  This is not compulsory for Junior Developers, or any member of staff, but if you
+  wish to participate in this work it is a good learning experience and
+  [attracts additional pay and TOIL](https://playbook.dxw.com/tech/support-and-on-call/#claiming-toil-for-out-of-hours-alerts).
+
+## Who will support you
+
+As a Junior Developer, you have the following direct support:
+
+* if you are new to the company, a helper (for dxw / ways of working related help and guidance).
+* a line manager (for both of those things and everything else).
+* the technical lead for each client project you work on, who will be on-hand to give you advice and pair with you.
+* A mentor, who is another developer that you will meet with regularly
+
+You are also supported by the GovPress team and the technology team as a whole.
+
+## Review points
+
+During your time as a Junior Developer there will be two or three "review points"
+where we will assess your progress over your rotations. These will be scheduled
+to fit in at sensible points in your schedule, for example at the end of a large
+project. The exact form of each review point will be communicated to you nearer
+the time, but we would expect you to reflect on your own work, and to get feedback
+from the colleagues you have worked with directly. This will use the same competency
+framework as the rest of the team.
+
+## Self-directed learning
+
+Your self-directed learning and development should be agreed in advance with your
+line manager. During your self-directed learning, you should start by working on
+projects chosen by your line manager, and as you gain in confidence in each of these
+areas, you should start to choose projects for yourself, based on your own development
+plans.
+
+### Learning and development projects
+
+The unit maintains a list of learning and development projects which are suitable
+for Junior Developers. Each of these projects is intended to be self-contained
+and to take a relatively small amount of time, which may be split up over several
+weeks, depending on your workload. Some projects are based on our experiences of
+working with developers at the start of their career, and some are external courses
+or tutorials.
+
+For some projects you might want to start by pairing with your line manager or
+another member of the team, others you might be happy to take on alone. Once you
+have completed each project, you should reflect on what you have learned with your
+line manager. The projects maintained by the unit are not tied to any particular
+programming language or technology, you are free to choose PHP or any other language
+for their implementation, but some choices will make the work harder than others,
+so do ask your line manager before you start.
+
+You will notice that some technologies and systems we use in GovPress are not
+represented in the project ideas we maintain. This is because we would expect
+that you will learn enough about those parts of your work on client projects
+that you should not need to make time for extra learning. However, if you feel
+that you are falling behind on any aspect of your work, you should ask your line
+manager to think about adding a small project here to help you.
+
+The intention here is to help you understand some of the background to the day to
+day work you are doing in GovPress. If you complete the technical work for these
+projects but you do not understand the result, you haven't finished. Equally,
+if you have met the learning outcomes, it doesn't matter whether or not you have
+run out of time to finish the practical work. If you and your line manager agree
+that you have already met the learning outcomes for some of these projects, they
+can be replaced with something you have not yet learned. The priority here is to
+deepen your understanding of your work, not to jump through hoops.

--- a/src/govpress-unit/junior-developer-plan.md
+++ b/src/govpress-unit/junior-developer-plan.md
@@ -1,5 +1,5 @@
 ---
-title: Junior developer development plan
+title: Development plans - Junior developers
 last_reviewed_at: ""
 ---
 


### PR DESCRIPTION
* Fix a typo
* Add Junior Developer development plan (previously kept in a GDoc)
* Rename both GovPress development plans to keep them together in the nav sidebar without adding another level of indirection