### PR TITLE
Create Staff handbook page “internal-comms”

### DIFF
--- a/src/staff-handbook/talking-about-what-we-do/internal-comms.md
+++ b/src/staff-handbook/talking-about-what-we-do/internal-comms.md
@@ -1,0 +1,50 @@
+---
+title: Internal comms
+last_reviewed_at: 2024-08-06T14:55:48.221Z
+---
+# Internal communications
+
+Our internal communications aim to keep everyone at dxw up-to-date and engaged with our priorities, progress, projects and ways of working. 
+
+We use a range of internal channels to help us share information, ask questions, make suggestions, collaborate and do social things.
+
+We want everyone to feel connected to our mission and part of the team.
+
+## Playbook
+
+The Playbook is where we explain our agreed ways of working. It’s also where we publish pay, benefits and other people policy information.
+
+The main audience for the Playbook is staff, but it’s available to anyone because we think there’s value in our clients and people who might come to work here knowing how we do things.
+
+## Bikesheds
+
+Bikesheds are internal blog posts that go to everyone in the company. Anyone can publish a Bikeshed and they are automatically shared via Slack #general and email. 
+
+We publish certain types of Bikesheds regularly:
+
+* Company weeknote - each week one of the Directors shares important news and actions, together with some personal thoughts
+* Announcements - company news, new policies and guidance, calls to action for staff. If the content of a Bikeshed will need to be referred to on an ongoing basis, this information should be added to the Playbook
+* Project weeknotes - regular updates from project teams about our progress on individual client projects
+
+## Slack
+
+Slack is the online equivalent of the office. It enables us to have conversations with the whole company, groups and individuals in public or private channels. 
+
+Messages are usually short and relatively informal and often point to sources of more detailed information. For example, a Bikeshed, the Playbook, or an external link.
+
+[Guidance on how we use Slack](https://playbook.dxw.com/staff-handbook/guidance-on-using-slack/) 
+
+## Meetings and other get-togethers
+
+We meet regularly online or in person. Sometimes as the whole company or more often in project, profession or other groups.
+
+We do this to share important information, work together on internal or external projects, team build or just get to know each other better.
+
+Regular company meet-ups open to all staff include:
+
+* Quarterly CEO update (online) - a regular update from our CEO on company priorities and how we’re doing
+* Monthly Directors’ drop-ins (online) - informal meetings with a couple of the Directors to discuss current issues and ask any questions
+* Monthly finance clinics (online) - an update on how we’re performing against our financial targets hosted by the Finance Director and CEO
+* Show the thing (online) - a programme of 6 weekly sessions every quarter with short demos from staff showing things they’re doing, building or learning
+* All-staff unconferences (in person with an online option) - an annual company event where staff determine the agenda
+* All-staff parties (in person) - we aim to get the company together socially in the Summer and at Christmas whenever we can


### PR DESCRIPTION
We take [this work add this new internal-comms page](https://github.com/dxw/playbook/pull/1366) and move it to the section "Talking about what we do". For some reason I couldn't reopen and change the original PR.