### PR TITLE
Update Airtable links

### DIFF
--- a/src/govpress-unit/support.md
+++ b/src/govpress-unit/support.md
@@ -154,7 +154,7 @@ put the main script on your $PATH)
 
 And make sure you have the [`govpress-developer-docs`](https://github.com/dxw/govpress-developer-docs)
 repo and [`ops/docs` repo](https://git.govpress.com/ops/docs/) bookmarked, along
-with the [Project Knowledgebase on AirTable](https://airtable.com/appNpQYEz4XOan53g/tblne7bw5jfACz2XB/viw13NhyxHHRuBHoH?blocks=hide).
+with the [Project Knowledgebase on AirTable](https://airtable.com/appL5dzrJCzmldhcG/tbllUuMjfRR8Npe61/viwsS1RB8nJZjBekX?blocks=hide).
 
 Please also ensure that you have the [incident.io](https://incident.io/) app
 installed in Slack, that you can access the [Dashboard](https://app.incident.io/dashboard)

--- a/src/tech/dealing-with-an-incident.md
+++ b/src/tech/dealing-with-an-incident.md
@@ -94,7 +94,7 @@ depend on the incident, but we mostly run simple websites so the following are
 always good steps:
 
 * Is the site or server available? Use
-  [Airtable](https://airtable.com/tblne7bw5jfACz2XB/viwF0lQjetG2ICuO2?blocks=hide)
+  [Airtable](https://airtable.com/appL5dzrJCzmldhcG/tbllUuMjfRR8Npe61/viwsS1RB8nJZjBekX?blocks=hide)
   to discover the URL
 * Check if this alert is a currently known event in ops/docs and read any
   previous guidance

--- a/src/tech/getting-a-project-ready-for-support.md
+++ b/src/tech/getting-a-project-ready-for-support.md
@@ -41,7 +41,7 @@ documentation to effectively solve problems. For most projects:
 
 ## Add the project to Project Knowledgebase
 
-Our [Project Knowledgebase](https://airtable.com/tblne7bw5jfACz2XB/) is the
+Our [Project Knowledgebase](https://airtable.com/appL5dzrJCzmldhcG/tbllUuMjfRR8Npe61/viwsS1RB8nJZjBekX?blocks=hide) is the
 starting point for support agents who are new to a project - it displays key
 information about the project alongside requests in Zendesk. Each project should
 have a row in the Projects table which has been completed.


### PR DESCRIPTION
We recently changed the way we use Airtable and this commit updates our current documentation to point to the live data.