### PR TITLE
Fix contributing links

### DIFF
--- a/src/_includes/contribute.html
+++ b/src/_includes/contribute.html
@@ -2,20 +2,23 @@
   {% assign collection_name = "home" %}
   {% assign entry_name = "home" %}
 {% else %}
-  {% assign path_parts = page.url | split: "/" %}
-  {% assign collection_parts_length = path_parts.size | minus: 2 %}
-  {% if collection_parts_length < 1 %}
-    {% assign collection_name = path_parts %}
+  {% assign child_page_count = site.pages | children_of: page | where_exp: "child", "child.title != 'Search'" | size %}
+  {% assign path_parts = page.url | slice: 1, page.url.size | split: "/" %}
+
+  {% if child_page_count > 0 %}
+    {% assign collection_name = path_parts | join: "__" %}
     {% assign entry_name = "index" %}
   {% else %}
-    {% assign collection_name = path_parts | slice: 1, collection_parts_length | join: "__" %}
+    {% assign collection_parts_size = path_parts.size | minus: 1 %}
+    {% assign collection_name = path_parts | slice: 0, collection_parts_size | join: "__" %}
     {% assign entry_name = path_parts | last %}
   {% endif %}
 {% endif %}
 
 <div class="contribute" data-proofer-ignore>
   <a href="/admin/#/collections/{{ collection_name }}/entries/{{ entry_name }}">Edit page</a>
-  {% unless page.url == "/" %}
+
+  {% if page.url != "/" and child_page_count > 0 %}
     <a href="/admin/#/collections/{{ collection_name }}/new">Add new page</a>
-  {% endunless %}
+  {% endif %}
 </div>


### PR DESCRIPTION
At present, when you're on the "Benefits" page, clicking on "Add new page" will take you to a form for adding a new "Pay, pension, and benefits" page, the parent of "Benefits". This might have made sense in a previous iteration of the menu/layout, but at present it's confusing. This updates things so that:
- the homepage only allows you to edit itself, not add a new page (no change)
- other pages with children allow you to edit the page, and clicking "Add new page" will take you to the CMS page for adding a child of that page (not a sibling, as is presently the case)
- other pages without children will only allow you to edit the page

We aim to keep the `src/admin/config.yml` up-to-date with pages that have children, in order to allow creation of new children via the CMS, but in cases where we haven't kept things up to date, bad CMS links should simply redirect to the main CMS page