### PR TITLE
Move scss property to above nested property

### DIFF
--- a/src/_sass/_contribute.scss
+++ b/src/_sass/_contribute.scss
@@ -3,6 +3,8 @@
 @use "./typography";
 
 .contribute {
+  display: none;
+  
   @include breakpoints.on-large-screens {
     position: fixed;
     bottom: 0;
@@ -25,5 +27,5 @@
     }
   }
 
-  display: none;
+  
 }


### PR DESCRIPTION
Running lint on the project stylesheets give the following warning:

```
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
```

This change moves our one declaration which breaks this rule, and does not affect the behaviour (contribution links should only display on large screens).

## Screenshots

<img width="1440" alt="" src="https://github.com/user-attachments/assets/3f6ebbd7-08a9-48d6-be9c-1641d37da393" />
<p>dxw Playbook homepage on a large screen, with an 'Edit page' link on the bottom left</p>


<img width="1440" alt="" src="https://github.com/user-attachments/assets/c39152aa-4de4-4fb5-b428-b6309adcdf77" />
<p>dxw Playbook about page on a large screen, with 'Edit page' and 'Add new page' links on the bottom left</p>


<img width="500" alt="Screenshot 2024-12-24 at 10 02 15" src="https://github.com/user-attachments/assets/1c886c68-1a12-4d12-80d6-1469da8586c9" />
<p>dxw Playbook about page on a small screen, with no 'Edit page' or 'Add new page' links</p>
