### PR TITLE
Update authenticated hrefs to exclude in html proofer

### DIFF
--- a/script/utils/check-html
+++ b/script/utils/check-html
@@ -23,9 +23,10 @@ IGNORE_HTTP_STATUS="200"
 #   https://github.com/jekyll/jekyll/blob/master/script/proof
 IGNORE_AUTHENTICATED_HREFS=$(ruby -e 'puts %w{
   expenses.xero.com/!wrUP-/detail/create-new/
-  github.com/dxw/govpress-developer-docs
-  github.com/dxw/judiciary-middleware
-  github.com/dxw/mind-side-by-side
+  github.com/dxw
+  docs.google.com
+  linkedin.com
+  git.govpress.com
 }.map{ |url| "/#{url}/" }.join(",")')
 
 IGNORE_ANY_OTHER_FALSE_POSITIVE_HREFS=$(ruby -e 'puts %w{


### PR DESCRIPTION
We currently use the [html-proofer](https://github.com/gjtorikian/html-proofer) plugin to help us catch broken links in the playbook. 

Some external links in the playbook are authenticated due to privacy level, or will be directed to an authentication screen for other reasons (e.g. LinkedIn). Updating the list to include more domains that currently fail the script for this reason.

Replacing the dxw private repository links with a catch-all for the dxw GitHub organisation, as there quite a few links to private repositories and adding them individually will be harder to maintain.