### PR TITLE
Update redundant links

### DIFF
--- a/src/about-us/our-mission-values-and-principles.md
+++ b/src/about-us/our-mission-values-and-principles.md
@@ -115,7 +115,7 @@ However, there are some things that we must keep private.
   never share any of this data, including contact details. See also:
   [data protection](/staff-handbook/data-protection-and-confidentiality).
 * We are sometimes sent documents that are
-  [protectively marked](/staff-handbook/data-protection-and-confidentiality/#document-labelling),
+  [protectively marked](/staff-handbook/data-protection-and-confidentiality/#document-labeling),
   and we have a scheme of our own. Information in these documents is
   confidential.
 * Information about work that is currently being procured (whether we are

--- a/src/index.md
+++ b/src/index.md
@@ -15,7 +15,7 @@ done. What’s written here is the way we do things now. Until we find something
 better, and write that down.
 
 This Playbook was originally inspired by
-[Thoughtbot's excellent playbook](https://playbook.thoughtbot.com/). Thanks,
+[Thoughtbot's excellent playbook](https://thoughtbot.com/playbook). Thanks,
 Thoughtbot!
 
 ## Updating the Playbook

--- a/src/tech/dealing-with-an-incident.md
+++ b/src/tech/dealing-with-an-incident.md
@@ -104,7 +104,7 @@ always good steps:
   the impact of this event (looking at logs, metrics etc.)
 
 Once you have identified the problem see if there is an
-[Ops Docs](https://github.com/ops-docs) guide for this error.
+[Ops Docs](https://github.com/dxw/ops-docs) guide for this error.
 
 ### Declaring an incident
 

--- a/src/tech/getting-a-project-ready-for-support.md
+++ b/src/tech/getting-a-project-ready-for-support.md
@@ -63,7 +63,7 @@ to add, please ask in Slack.
 ## Add the project to the operations documentation
 
 Make sure the client has a document in the
-[operations documentation](https://github.com/ops-docs) repository. It
+[operations documentation](https://github.com/dxw/ops-docs) repository. It
 should include either documentation or (preferably) links to documentation for
 any on-boarding steps needed, and the front line support runbook.
 

--- a/src/tech/support-and-on-call.md
+++ b/src/tech/support-and-on-call.md
@@ -6,7 +6,7 @@ last_reviewed_at: ""
 ---
 We have agreed service levels for each client we provide support for. Our standard terms, including prioritisation definitions and response times, are detailed in our Service Level Agreement.
 
-With our default support plan we manage all code, maintenance, updates, and uptime monitoring and provide security event monitoring intended to detect and prevent attacks. Users can also use our helpdesk service to ask for help with their service as outlined in [providing technical support](https://playbook.dxw.com/work-we-do/providing-technical-support/).
+With our default support plan we manage all code, maintenance, updates, and uptime monitoring and provide security event monitoring intended to detect and prevent attacks. Users can also use our helpdesk service to ask for help with their service as outlined in [providing technical support](/work-we-do/providing-techical-support/).
 
 We provide support for clients and users of these services in three ways:
 

--- a/src/tech/support-and-on-call.md
+++ b/src/tech/support-and-on-call.md
@@ -28,7 +28,7 @@ Being on call means you are the first line support for issues that occur out of 
 
 While on call, your responsibility is making sure all the services we support are running correctly and effectively.
 
-As with in-hours support, we use monitoring and alerts to notify you when an issue occurs via Opsgenie, and provide [runbooks](https://github.com/ops-docs) to help you respond to those issues. The difference to in-hours support is that you’ll only be alerted when a high-severity issue occurs, and you aren’t expected to take any action out of hours unless alerted.
+As with in-hours support, we use monitoring and alerts to notify you when an issue occurs via Opsgenie, and provide [runbooks](https://github.com/dxw/ops-docs) to help you respond to those issues. The difference to in-hours support is that you’ll only be alerted when a high-severity issue occurs, and you aren’t expected to take any action out of hours unless alerted.
 
 Outside office hours, the expected response depends on the severity of the incident. We have a set of factors that determine the severity of an incident, and have included these in our [Service Level Agreement](https://contracts.dxw.com/service_level_agreement.md).
 

--- a/src/user-research/choosing-and-using-analysis-and-synthesis-methods.md
+++ b/src/user-research/choosing-and-using-analysis-and-synthesis-methods.md
@@ -181,6 +181,6 @@ There are a number of ways we can create the codes. We can start with a set of p
 * [How to Analyze Qualitative Data from UX Research: Thematic Analysis](https://www.nngroup.com/articles/thematic-analysis/)
 * [Qualitative data coding 101 at Grad Coach](https://gradcoach.com/qualitative-data-coding-101/)
 * [An Introduction to Codes and Coding by Saldana (book chapter)](https://www.sagepub.com/sites/default/files/upm-binaries/24614_01_Saldana_Ch_01.pdf)
-* [Grounded Theory: A Practical Guide by Birks and Mills](https://uk.sagepub.com/en-gb/eur/grounded-theory/book243177)
+* [Grounded Theory: A Practical Guide by Birks and Mills](https://uk.sagepub.com/en-gb/eur/grounded-theory/book276752)
 * [Qualitative Data Analysis: A Methods Sourcebook by Miles, Huberman and Saldana](https://us.sagepub.com/en-us/nam/qualitative-data-analysis/book246128)
 (quite expensive new, but can often get cheaper second hand copies)

--- a/src/user-research/making-research-activities-inclusive-and-accessible.md
+++ b/src/user-research/making-research-activities-inclusive-and-accessible.md
@@ -137,7 +137,7 @@ So our entire face and lips are visible.
 
 Many people benefit from reading captions, not only people who are Deaf/deaf.
 
-Some [neurodivergent people use them](https://mindfulresearch.co.uk/2011/08/29/autistic-spectrum-captions-and-audio-description/). And people for whom English is an additional language can find them helpful.
+Some [neurodivergent people use them](https://sunsurfer.co.uk/autistic-spectrum-captions-and-audio-description/). And people for whom English is an additional language can find them helpful.
 
 ## Making in person research inclusive
 


### PR DESCRIPTION
This updates any fixable links which fail the html-proofer script. 

It would be good to double check the following links are correct before merging:

- [Ops docs repository](https://github.com/dxw/ops-docs)
- [Grounded theory book](https://uk.sagepub.com/en-gb/eur/grounded-theory/book276752) (user research recommended reading)