### PR TITLE
Specify how to access media library files

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -18,6 +18,7 @@ backend:
   branch: main
   open_authoring: true
 media_folder: src/assets/images
+public_folder: assets/images
 publish_mode: editorial_workflow
 show_preview_links: true
 collection_defaults: &collection_defaults


### PR DESCRIPTION
  When a user was adding an image in the Decap CMS (FKA Netlify CMS), the generated link included the `src/` at the start. We need the `src/` to tell GitHub where to store the file, but on the built site, `src/` is omitted from the path and we need to go straight to the `assets` folder. This should hopefully do the trick

https://decapcms.org/docs/configuration-options/#media-and-public-folders:~:text=static/images/uploads%22-,Public%20Folder,-The%20public_folder%20option

I can't test this locally, since running the CMS locally already requires messing with paths: https://github.com/dxw/playbook/commit/9eb5e7f5e20e2fc86719e4605ec1bc89a16eaed3