### PR TITLE
Allow tech incidents editing in CMS

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -165,6 +165,11 @@ collections:
     label: Technology
     label_singular: Technology page
     folder: src/tech
+  - <<: *collection_defaults
+    name: tech__incidents
+    label: Technology > Incidents
+    label_singular: Incidents page
+    folder: src/tech/incidents
 
   - <<: *collection_defaults
     name: user-research


### PR DESCRIPTION
This folder was missing from the config that specifies in which directories pages can be added or edited