### PR TITLE
Fix redirects for parental leave

### DIFF
--- a/src/redirects.json
+++ b/src/redirects.json
@@ -14,7 +14,7 @@
       },
       {
         "from": "/staff-handbook/leave/parental-leave/",
-        "to": "/staff-handbook/policies-and-procedures/parental-leave-policy"
+        "to": "/staff-handbook/policies-and-procedures/parental-leave"
       },
       {
         "from": "/staff-handbook/pay-pension-and-benefits/pay/",

--- a/src/staff-handbook/policies-and-procedures/parental-leave.md
+++ b/src/staff-handbook/policies-and-procedures/parental-leave.md
@@ -1,6 +1,8 @@
 ---
 title: Parental leave policy
 related_order: 4
+redirect_from:
+  - /staff-handbook/policies-and-procedures/parental-leave-policy
 last_reviewed_at: ""
 ---
 We’re aware that there is a lot to take in here - please come and talk to the


### PR DESCRIPTION
In 664291347e0c88c215926618a66f2e9f4346792e, we changed the path for the parental leave page in the policy section of the playbook. However, we didn't:
- update the redirect from `/staff-handbook/leave/parental-leave`  in the redirects.json file. This means that the link from the leave index is broken
- create a new general redirect from `/staff-handbook/policies-and-procedures/parental-leave-policy`

This does both of these