### PR TITLE
Fix pages not appearing in menu

### DIFF
--- a/src/staff-handbook/policies-and-procedures/parental-leave/if-you-are-adopting-or-having-a-baby-through-surrogacy.md
+++ b/src/staff-handbook/policies-and-procedures/parental-leave/if-you-are-adopting-or-having-a-baby-through-surrogacy.md
@@ -1,5 +1,5 @@
 ---
-title: If you’re adopting or having a baby through surrogacy
+title: If you are adopting or having a baby through surrogacy
 last_reviewed_at: ""
 ---
 ## What dxw offers

--- a/src/staff-handbook/policies-and-procedures/parental-leave/if-you-are-pregnant.md
+++ b/src/staff-handbook/policies-and-procedures/parental-leave/if-you-are-pregnant.md
@@ -1,5 +1,5 @@
 ---
-title: If you’re pregnant
+title: If you are pregnant
 last_reviewed_at: ""
 ---
 A person giving birth must take at least the first 2 weeks after the birth as parental leave.


### PR DESCRIPTION
These pages don't appear in the menu because of having apostrophes in their filenames and/or titles (haven't quite gotten to the bottom of the problem). I tried changing the character from `’` to `'` but that didn't fix it. The easiest solution seems to be avoiding the contraction altogether, which also brings these pages in line with the sibling "If you are the secondary carer" page