### PR TITLE
Remove deprecated CSS clip property

### DIFF
--- a/src/_sass/_accessibility.scss
+++ b/src/_sass/_accessibility.scss
@@ -11,6 +11,5 @@
 
   white-space: nowrap !important;
 
-  clip: rect(0 0 0 0) !important;
   clip-path: inset(50%) !important;
 }


### PR DESCRIPTION
The [`clip` property](https://developer.mozilla.org/en-US/docs/Web/CSS/clip) has been deprecated for a while now, and its [replacement](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path) has been widely supported since 2020.